### PR TITLE
feat: repository function name as action type

### DIFF
--- a/docs/docs/dev-tools.mdx
+++ b/docs/docs/dev-tools.mdx
@@ -21,3 +21,16 @@ The plugin supports the following options passed as the second function paramete
 `maxAge`: Maximum amount of actions to be stored in the history tree.
 
 `preAction`: A method that's called before each action.
+
+`getActionType`: Get the current action type, for example:
+
+```
+devTools({
+  getActionType: (state: any): string => {
+    // Attempt to get the repository's callee
+    const stack = (new Error()).stack?.split('\n') || [];
+    const updateIdx = stack.findIndex((e: string) => e.startsWith('update@'));
+    return updateIdx >= 0 ? stack[updateIdx + 1].split('@')[0] : 'Update';
+  }
+});
+```

--- a/packages/devtools/README.md
+++ b/packages/devtools/README.md
@@ -1,4 +1,3 @@
 # @ngneat/elf-devtools
 
 [Docs](https://ngneat.github.io/elf/docs/dev-tools)
-

--- a/packages/devtools/src/lib/devtools.spec.ts
+++ b/packages/devtools/src/lib/devtools.spec.ts
@@ -15,9 +15,13 @@ describe('devtools', () => {
         connect: jest.fn().mockImplementation(() => instanceMock),
       },
     },
+    configurable: true,
+    writable: true,
   });
 
-  createEntitiesStore('books');
+  const bookStore = createEntitiesStore('books');
+  let barStore: any;
+  let fooStore: any;
 
   devTools();
 
@@ -83,7 +87,7 @@ describe('devtools', () => {
       }
     );
 
-    createEntitiesStore('foo');
+    fooStore = createEntitiesStore('foo');
 
     expect(instanceMock.send).toHaveBeenCalledWith(
       { type: '[Foo] - @Init' },
@@ -99,7 +103,7 @@ describe('devtools', () => {
       }
     );
 
-    const bar = createEntitiesStore('bar');
+    barStore = createEntitiesStore('bar');
 
     expect(instanceMock.send).toHaveBeenCalledWith(
       { type: '[Bar] - @Init' },
@@ -119,7 +123,7 @@ describe('devtools', () => {
       }
     );
 
-    bar.update(addEntities(createTodo(1)));
+    barStore.update(addEntities(createTodo(1)));
 
     expect(instanceMock.send).toHaveBeenCalledWith(
       { type: '[Bar] - Update' },
@@ -145,4 +149,52 @@ describe('devtools', () => {
       }
     );
   });
+
+  afterAll(() => {
+    bookStore.destroy();
+    fooStore.destroy();
+    barStore.destroy();
+  });
+});
+
+describe('devtools - getActionType', () => {
+  const instanceMock = {
+    init: jest.fn(),
+    subscribe: jest.fn(),
+    send: jest.fn(),
+  };
+
+  Object.defineProperty(global, 'window', {
+    value: {
+      __REDUX_DEVTOOLS_EXTENSION__: {
+        connect: jest.fn().mockImplementation(() => instanceMock),
+      },
+    },
+  });
+
+  devTools({ getActionType: (_: any): string => 'Hello' });
+
+  const store = createEntitiesStore();
+
+  it('should get action type', () => {
+    store.update(addEntities(createTodo(1)));
+
+    expect(instanceMock.send).toHaveBeenCalledWith(
+      { type: '[Todos] - Hello' },
+      {
+        todos: {
+          entities: {
+            1: {
+              completed: false,
+              id: 1,
+              title: 'todo 1',
+            },
+          },
+          ids: [1],
+        },
+      }
+    );
+  });
+
+  afterAll(() => store.destroy());
 });

--- a/packages/devtools/src/lib/devtools.ts
+++ b/packages/devtools/src/lib/devtools.ts
@@ -16,6 +16,7 @@ interface DevtoolsOptions {
   name?: string;
   preAction?: () => void;
   actionsDispatcher?: ActionsDispatcher;
+  getActionType?: (state: any) => string;
 }
 
 declare global {
@@ -52,9 +53,10 @@ export function devTools(options: DevtoolsOptions = {}) {
 
     send({ type: `[${displayName}] - @Init` });
 
-    const update = store.pipe(skip(1)).subscribe(() => {
+    const update = store.pipe(skip(1)).subscribe((state) => {
       options.preAction?.();
-      send({ type: `[${displayName}] - Update` });
+      const actionType = options.getActionType?.(state) || 'Update';
+      send({ type: `[${displayName}] - ${actionType}` });
     });
 
     subscriptions.set(name, update);
@@ -79,9 +81,10 @@ export function devTools(options: DevtoolsOptions = {}) {
     if (type === 'add') {
       send({ type: `[${displayName}] - @Init` });
 
-      const update = store.pipe(skip(1)).subscribe(() => {
+      const update = store.pipe(skip(1)).subscribe((state) => {
         options.preAction?.();
-        send({ type: `[${displayName}] - Update` });
+        const actionType = options.getActionType?.(state) || 'Update';
+        send({ type: `[${displayName}] - ${actionType}` });
       });
 
       subscriptions.set(name, update);


### PR DESCRIPTION
It's a rather naive and maybe not 100% functional way of doing it but it's prettier:

![20211117_18h16m37s_grim](https://user-images.githubusercontent.com/1321971/142249359-97c9577a-978e-4fc5-a02a-de6231622129.png)

Feel free to close this if it isn't worth it in your opinion.