### PR TITLE
feat(entities): upsertEntities mutator

### DIFF
--- a/docs/docs/examples/entities-props.ex.ts
+++ b/docs/docs/examples/entities-props.ex.ts
@@ -2,7 +2,7 @@ import { createState, Store } from '@ngneat/elf';
 import {
   withEntities,
   entitiesPropsFactory,
-  upsertEntities,
+  upsertEntitiesById,
   addEntities,
 } from '@ngneat/elf-entities';
 
@@ -32,7 +32,7 @@ productsStore.subscribe((value) => {
 
 productsStore.update(
   addEntities({ id: 1, title: 'one', price: 55 }),
-  upsertEntities(1, {
+  upsertEntitiesById(1, {
     updater: (e) => ({ ...e, quantity: e.quantity + 1 }),
     creator: (id) => ({ id, quantity: 1 }),
     ref: cartEntitiesRef,

--- a/docs/docs/features/entities/entities-props-factory.mdx
+++ b/docs/docs/features/entities/entities-props-factory.mdx
@@ -19,9 +19,7 @@ interface Product {
   price: number;
 }
 
-const { state, config } = createState(
-  withEntities<Product>()
-)
+const { state, config } = createState(withEntities<Product>());
 
 export const productsStore = new Store({ name: 'products', config, state });
 ```
@@ -49,7 +47,7 @@ interface CartItem {
 const { state, config } = createState(
   withEntities<Product>(),
   withCartEntities<CartItem>()
-)
+);
 
 export const productsStore = new Store({ name: 'products', config, state });
 ```
@@ -72,21 +70,20 @@ In the above example, our final `state` shape will be:
 <LiveDemo src={index} packages={['entities']} />
 <br />
 
-
 We can pass the `cartEntitiesRef` to each one of the built-in [queries](./entities#queries) and [mutations](./entities#mutations):
 
 ```ts title="products.repository.ts"
-import { upsertEntities } from '@ngneat/elf-entities';
+import { upsertEntitiesById } from '@ngneat/elf-entities';
 
 export function updateCart(id: Product['id']) {
   productsStore.update(
-    upsertEntities(id, {
-      updater: e => ({ ...e, quantity: e.quantity + 1 }),
-      creator: id => ({ id, quantity: 1 }),
+    upsertEntitiesById(id, {
+      updater: (e) => ({ ...e, quantity: e.quantity + 1 }),
+      creator: (id) => ({ id, quantity: 1 }),
       // highlight-next-line
-      ref: cartEntitiesRef
+      ref: cartEntitiesRef,
     })
-  )
+  );
 }
 ```
 
@@ -127,8 +124,11 @@ const store = new Store({ name: 'movies', state, config });
 store.update(
   addEntities({ id: '1', name: 'Nicolas cage' }, { ref: actorsEntitiesRef }),
   addEntities({ id: '1', name: 'Action' }, { ref: genresEntitiesRef }),
-  addEntities({ id: '1', title: 'Gone in 60 Seconds', genres: ['1'], actors: ['1'] })
-)
+  addEntities({
+    id: '1',
+    title: 'Gone in 60 Seconds',
+    genres: ['1'],
+    actors: ['1'],
+  })
+);
 ```
-
-

--- a/docs/docs/features/entities/entities.mdx
+++ b/docs/docs/features/entities/entities.mdx
@@ -180,9 +180,7 @@ Replace current collection with the provided collection:
 ```ts
 import { setEntities } from '@ngneat/elf-entities';
 
-todosStore.update(
-  setEntities([todo, todo])
-);
+todosStore.update(setEntities([todo, todo]));
 ```
 
 ### `addEntities`
@@ -192,17 +190,11 @@ Add an entity or entities to the store:
 ```ts
 import { addEntities } from '@ngneat/elf-entities';
 
-todosStore.update(
-  addEntities(todo)
-);
+todosStore.update(addEntities(todo));
 
-todosStore.update(
-  addEntities([todo, todo])
-);
+todosStore.update(addEntities([todo, todo]));
 
-todosStore.update(
-  addEntities([todo, todo], { prepend: true })
-);
+todosStore.update(addEntities([todo, todo], { prepend: true }));
 ```
 
 ### `addEntitiesFifo`
@@ -212,9 +204,7 @@ Add an entity or entities to the store using fifo strategy:
 ```ts
 import { addEntitiesFifo } from '@ngneat/elf-entities';
 
-todosStore.update(
-  addEntitiesFifo([entity, entity]), { limit: 3 }
-);
+todosStore.update(addEntitiesFifo([entity, entity]), { limit: 3 });
 ```
 
 ### `updateEntities`
@@ -224,17 +214,11 @@ Update an entity or entities in the store:
 ```ts
 import { updateEntities } from '@ngneat/elf-entities';
 
-todosStore.update(
-  updateEntities(id, { name })
-);
+todosStore.update(updateEntities(id, { name }));
 
-todosStore.update(
-  updateEntities(id, (entity) => ({ ...entity, name }))
-);
+todosStore.update(updateEntities(id, (entity) => ({ ...entity, name })));
 
-todosStore.update(
-  updateEntities([id, id, id], { open: true })
-);
+todosStore.update(updateEntities([id, id, id], { open: true }));
 ```
 
 ### `updateEntitiesByPredicate`
@@ -245,17 +229,12 @@ Update an entity or entities in the store:
 import { updateEntitiesByPredicate } from '@ngneat/elf-entities';
 
 todosStore.update(
-  updateEntitiesByPredicate(
-    ({ count }) => count === 0,
-    { open: false }
-  )
+  updateEntitiesByPredicate(({ count }) => count === 0, { open: false })
 );
 
 todosStore.update(
-  updateEntitiesByPredicate(
-   ({ count }) => count === 0),
-   (entity) => ({ ...entity, open: false }
-  )
+  updateEntitiesByPredicate(({ count }) => count === 0),
+  (entity) => ({ ...entity, open: false })
 );
 ```
 
@@ -266,9 +245,7 @@ Update all entities in the store:
 ```ts
 import { updateAllEntities } from '@ngneat/elf-entities';
 
-todosStore.update(
-  updateAllEntities({ name: 'elf' })
-);
+todosStore.update(updateAllEntities({ name: 'elf' }));
 
 todosStore.update(
   updateAllEntities((entity) => ({ ...entity, count: entity.count + 1 }))
@@ -277,24 +254,60 @@ todosStore.update(
 
 ### `upsertEntities`
 
+Add or update entities.
+
+All entities must have an `id` property so we can identify them in the store.
+
+You can pass in partial entities and they will be merged with the existing ones.
+
+```ts
+import { upsertEntitiesBy } from '@ngneat/elf-entities';
+
+// update an existing entity
+todosStore.update(
+  // add an elf
+  addEntities({ id: '1', name: 'elf' }),
+  // update him to be happy
+  upsertEntities({ id: '1', happy: true })
+);
+```
+
+Or you can use it with an array
+
+```ts
+import { upsertEntitiesBy } from '@ngneat/elf-entities';
+
+todosStore.update(
+  addEntities({ id: '1', name: 'elf' }),
+  upsertEntities([
+    // will update elf 1
+    { id: '1', happy: true },
+    // will add elf 2
+    { id: '2', name: 'elf 2' },
+  ])
+);
+```
+
+### `upsertEntitiesById`
+
 Insert or update an entity. When the id isn't found, it creates a new entity; otherwise, it performs an update:
 
 ```ts
-import { upsertEntities } from '@ngneat/elf-entities';
+import { upsertEntitiesById } from '@ngneat/elf-entities';
 
 const creator = (id) => createTodo(id);
 
 todosStore.update(
-  upsertEntities(1, {
+  upsertEntitiesById(1, {
     updater: { name: 'elf' },
-    creator
+    creator,
   })
 );
 
 todosStore.update(
-  upsertEntities([1, 2], {
+  upsertEntitiesById([1, 2], {
     updater: (entity) => ({ ...entity, count: entity.count + 1 }),
-    creator
+    creator,
   })
 );
 ```
@@ -303,16 +316,16 @@ To perform a merge between a new entity and an `updater` result, use the `mergeU
 
 ```ts
 todosStore.update(
-  upsertEntities([1, 2], {
+  upsertEntitiesById([1, 2], {
     updater: (entity) => ({ ...entity, name }),
     creator,
     // highlight-next-line
-    mergeUpdaterWithCreator: true
+    mergeUpdaterWithCreator: true,
   })
 );
 ```
 
-The above example will first create the entity using the *creator* method, then pass the result to the *updater* method, and merge both.
+The above example will first create the entity using the _creator_ method, then pass the result to the _updater_ method, and merge both.
 
 ### `deleteEntities`
 
@@ -332,9 +345,7 @@ Delete an entity or entities from the store:
 ```ts
 import { deleteEntitiesByPredicate } from '@ngneat/elf-entities';
 
-todosStore.update(
-  deleteEntitiesByPredicate(({ completed }) => completed)
-);
+todosStore.update(deleteEntitiesByPredicate(({ completed }) => completed));
 ```
 
 ### `deleteAllEntities`
@@ -369,6 +380,7 @@ const todosStore = new Store({ name: 'todos', state, config });
 ```
 
 ## initialValue
+
 In case that you need to start the `entities` state with a value, you can specify it in the `initialValue` configuration:
 
 ```ts

--- a/packages/entities/src/index.ts
+++ b/packages/entities/src/index.ts
@@ -9,6 +9,7 @@ export {
   updateAllEntities,
   updateEntities,
   updateEntitiesByPredicate,
+  upsertEntitiesById,
   upsertEntities,
 } from './lib/update.mutation';
 export { selectAll, selectEntities, selectAllApply } from './lib/all.query';

--- a/packages/entities/src/lib/__snapshots__/update.mutation.spec.ts.snap
+++ b/packages/entities/src/lib/__snapshots__/update.mutation.spec.ts.snap
@@ -1,6 +1,65 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`update Upsert should add the entity if it doesn't exists: two entities 1`] = `
+exports[`update Upsert should add the entity if it doesn't exists: one entities 1`] = `
+Object {
+  "entities": Object {
+    "1": Object {
+      "completed": false,
+      "id": 1,
+      "title": "todo 1",
+    },
+  },
+  "ids": Array [
+    1,
+  ],
+}
+`;
+
+exports[`update Upsert should merge fields on update: merged entity with completed: true 1`] = `
+Object {
+  "entities": Object {
+    "1": Object {
+      "completed": true,
+      "id": 1,
+      "title": "todo 1",
+    },
+  },
+  "ids": Array [
+    1,
+  ],
+}
+`;
+
+exports[`update Upsert should update the entity if it has the same id: updated entity with completed: true 1`] = `
+Object {
+  "entities": Object {
+    "1": Object {
+      "completed": true,
+      "id": 1,
+      "title": "todo 1",
+    },
+  },
+  "ids": Array [
+    1,
+  ],
+}
+`;
+
+exports[`update Upsert should work with ref: one ui entity, open true 1`] = `
+Object {
+  "UIEntities": Object {
+    "1": Object {
+      "id": 1,
+      "open": true,
+    },
+  },
+  "UIIds": Array [
+    1,
+  ],
+}
+`;
+
+exports[`update UpsertById should add the entity if it doesn't exists: two entities 1`] = `
 Object {
   "entities": Object {
     "1": Object {
@@ -21,7 +80,7 @@ Object {
 }
 `;
 
-exports[`update Upsert should merge updater with creator: two entities, title "elf" 1`] = `
+exports[`update UpsertById should merge updater with creator: two entities, title "elf" 1`] = `
 Object {
   "entities": Object {
     "1": Object {
@@ -42,7 +101,7 @@ Object {
 }
 `;
 
-exports[`update Upsert should update add the missing entities and update existing: two entities, 1: title "elf", 2: title "todo 2" 1`] = `
+exports[`update UpsertById should update add the missing entities and update existing: two entities, 1: title "elf", 2: title "todo 2" 1`] = `
 Object {
   "entities": Object {
     "1": Object {
@@ -63,7 +122,7 @@ Object {
 }
 `;
 
-exports[`update Upsert should update an entity if exists: one entity, title "elf" 1`] = `
+exports[`update UpsertById should update an entity if exists: one entity, title "elf" 1`] = `
 Object {
   "entities": Object {
     "1": Object {
@@ -78,7 +137,7 @@ Object {
 }
 `;
 
-exports[`update Upsert should work with ref: two entities, open true 1`] = `
+exports[`update UpsertById should work with ref: two entities, open true 1`] = `
 Object {
   "UIEntities": Object {
     "1": Object {


### PR DESCRIPTION
I took a stab at implementing the upsertEntities mutator, I hope you don't mind.
I haven't done the docs yet, because I wanted to get feedback before doing that.

What do you think, will this be a good implementation?

// Leon


## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngneat/elf/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

We haven't got an upsertEntities mutator, only an addEntities, and a upsertEntities (byId)

I renamed upsertEntities to upsertEntitiesById

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A
https://github.com/ngneat/elf/discussions/75

## What is the new behavior?

```ts
// single entity
store.update(upsertEntities({ id: 1, completed: true }))

// or multiple entities
store.update(upsertEntities([{ id: 1, completed: true }, { id: 2, completed: true }]))

// or using a custom ref
store.update(upsertEntities([{ id: 1, open: true }], { ref: UIEntitiesRef }))
```

## Does this PR introduce a breaking change?

```
[x] Yes
[ ] No
```

rename upsertEntities to upsertEntitiesById in your codebase


