### PR TITLE
fix(state-history): undo history glitch

### DIFF
--- a/packages/state-history/src/lib/state-history.spec.ts
+++ b/packages/state-history/src/lib/state-history.spec.ts
@@ -8,6 +8,18 @@ function eq(store: Store, value: number) {
 describe('state history', () => {
   const { withProp, setProp } = propsFactory('prop', { initialValue: 0 });
 
+  it('should set the current state', () => {
+    const { state, config } = createState(withProps({ counter: 0 }));
+    const store = new Store({ state, config, name: '' });
+    const history = stateHistory(store);
+
+    expect((history as any).history).toEqual({
+      past: [],
+      present: { counter: 0 },
+      future: [],
+    });
+  });
+
   it('should work', () => {
     const { state, config } = createState(withProp());
     const store = new Store({ state, config, name: '' });
@@ -111,5 +123,39 @@ describe('state history', () => {
     history.undo();
 
     expect(store.getValue()).toEqual(steps[0]);
+  });
+
+  it('should replace store on undo/redo', () => {
+    const { state, config } = createState(withProps({ counter: 5 }));
+    const store = new Store({ state, config, name: '' });
+    const history = stateHistory(store);
+
+    expect((history as any).history).toEqual({
+      past: [],
+      present: { counter: 5 },
+      future: [],
+    });
+    expect(store.getValue()).toEqual({ counter: 5 });
+
+    store.update((state) => ({
+      ...state,
+      newProperty: true,
+    }));
+
+    expect((history as any).history).toEqual({
+      past: [{ counter: 5 }],
+      present: { counter: 5, newProperty: true },
+      future: [],
+    });
+    expect(store.getValue()).toEqual({ counter: 5, newProperty: true });
+
+    history.undo();
+
+    expect((history as any).history).toEqual({
+      past: [],
+      present: { counter: 5 },
+      future: [{ counter: 5, newProperty: true }],
+    });
+    expect(store.getValue()).toEqual({ counter: 5 });
   });
 });

--- a/packages/state-history/src/lib/state-history.spec.ts
+++ b/packages/state-history/src/lib/state-history.spec.ts
@@ -1,5 +1,5 @@
 import { stateHistory } from './state-history';
-import { createState, propsFactory, Store } from '@ngneat/elf';
+import { createState, propsFactory, Store, withProps } from '@ngneat/elf';
 
 function eq(store: Store, value: number) {
   expect(store.getValue()).toEqual({ prop: value });
@@ -15,23 +15,25 @@ describe('state history', () => {
     const history = stateHistory(store);
 
     eq(store, 0);
-    store.update(setProp(1));
+
+    store.update(setProp(1)); // history [0, 1]
+
     eq(store, 1);
 
-    history.undo();
+    history.undo(); // history [0]
     eq(store, 0);
 
-    history.redo();
+    history.redo(); // history [0, 1]
     eq(store, 1);
 
-    store.update(setProp(2));
-    store.update(setProp(3));
+    store.update(setProp(2)); // history [0, 1, 2]
+    store.update(setProp(3)); // history [0, 1, 2, 3]
     eq(store, 3);
 
-    history.undo();
+    history.undo(); // history [0, 1, 2]
     eq(store, 2);
 
-    history.undo();
+    history.undo(); // history [0, 1]
     eq(store, 1);
 
     history.pause();
@@ -39,12 +41,75 @@ describe('state history', () => {
     store.update(setProp(4));
     store.update(setProp(5));
     eq(store, 5);
-    history.undo();
+    history.undo(); // history [0]
     eq(store, 0);
 
     history.resume();
-    store.update(setProp(1));
-    history.undo();
+
+    store.update(setProp(1)); // history [0, 1]
+    eq(store, 1);
+
+    history.undo(); // history [0]
+
+    history.undo(); // history [0]
+
     eq(store, 0);
+  });
+
+  it('should pause and resume correctly with partial update', () => {
+    const { state, config } = createState(withProps({ first: 0, second: 0 }));
+    const store = new Store({ state, config, name: '' });
+    const history = stateHistory(store);
+
+    const setFirst = (first: number) =>
+      store.update((state) => ({
+        ...state,
+        first,
+      }));
+
+    const setSecond = (second: number) =>
+      store.update((state) => ({
+        ...state,
+        second,
+      }));
+
+    const steps = [
+      { first: 0, second: 0 },
+      { first: 1, second: 0 },
+      { first: 2, second: 3 },
+      { first: 3, second: 3 },
+    ];
+
+    expect(store.getValue()).toEqual(steps[0]);
+
+    setFirst(1);
+
+    expect(store.getValue()).toEqual(steps[1]);
+
+    history.pause();
+    setSecond(1);
+    setSecond(2);
+    setSecond(3);
+    history.resume();
+
+    setFirst(2);
+
+    expect(store.getValue()).toEqual(steps[2]);
+
+    setFirst(3);
+
+    expect(store.getValue()).toEqual(steps[3]);
+
+    history.undo();
+
+    expect(store.getValue()).toEqual(steps[2]);
+
+    history.undo();
+
+    expect(store.getValue()).toEqual(steps[1]);
+
+    history.undo();
+
+    expect(store.getValue()).toEqual(steps[0]);
   });
 });


### PR DESCRIPTION
When stateHistory is paused, the previous value is partially retained when updating.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngneat/elf/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

[Issue Number: 91](https://github.com/ngneat/elf/issues/91)

## What is the new behavior?

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

## Other information
