### PR TITLE
fix(entities): correct typing for selectActiveEntity

### DIFF
--- a/packages/entities/src/lib/active/active.spec.ts
+++ b/packages/entities/src/lib/active/active.spec.ts
@@ -43,6 +43,10 @@ describe('activeId', () => {
     store.update(updateEntities(1, { title: 'foo' }));
     expect(spy).toHaveBeenCalledTimes(3);
     expect(spy).toHaveBeenCalledWith({ id: 1, title: 'foo' });
+
+    store.update(setActiveId(123));
+    expect(spy).toHaveBeenCalledTimes(4);
+    expect(spy).toHaveBeenNthCalledWith(4, undefined);
   });
 });
 

--- a/packages/entities/src/lib/active/active.ts
+++ b/packages/entities/src/lib/active/active.ts
@@ -25,7 +25,7 @@ export function selectActiveEntity<
   Ref extends EntitiesRef = DefaultEntitiesRef
 >(
   options: BaseEntityOptions<Ref> = {}
-): OperatorFunction<S, getEntityType<S, Ref>> {
+): OperatorFunction<S, getEntityType<S, Ref> | undefined> {
   const { ref = defaultEntitiesRef } = options;
 
   return function (source: Observable<S>) {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngneat/elf/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

_I am not sure if there should be a documentation update to accompany this._

## PR Type

What kind of change does this PR introduce?

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

The `selectActiveEntity` operator is typed such that the resulting observable appears to only ever emit an entity.

Issue Number: N/A

## What is the new behavior?

The typing now reflects that the resulting observable can also emit undefined if there is no active entity or if the active ID doesn't match an entity in the store.

## Does this PR introduce a breaking change?

```
[x] Yes
[ ] No
```

There is no breaking actual behavior change, but projects using `selectActiveEntity` could have broken builds due to the more correct typing information, especially projects that are more strict in their compilation.

## Other information
