### PR TITLE
feat(entities): 🔥 support id update

### DIFF
--- a/docs/docs/features/entities/entities.mdx
+++ b/docs/docs/features/entities/entities.mdx
@@ -296,6 +296,7 @@ todosStore.update(
   ])
 );
 ```
+
 ### `upsertEntitiesById`
 
 Insert or update an entity. When the id isn't found, it creates a new entity; otherwise, it performs an update:
@@ -334,6 +335,40 @@ todosStore.update(
 ```
 
 The above example will first create the entity using the _creator_ method, then pass the result to the _updater_ method, and merge both.
+
+### `updateEntitiesIds`
+
+Update id of an entity or entities in the store:
+
+```ts
+import { updateEntitiesIds } from '@ngneat/elf-entities';
+
+todosStore.update(updateEntitiesIds(oldId, newId));
+
+todosStore.update(updateEntitiesIds([oldId1, oldId2], [newId1, newId2]));
+```
+
+The most common use case for this is "optimistic updates":
+
+```ts
+function addTodo(todo: Todo) {
+  const tempId = generateRandomId();
+  todosStore.update(addEntities({ ...todo, id: tempId }));
+
+  addTodoToServer(todo).then(
+    (response) => {
+      todosStore.update(
+        updateEntitiesIds(tempId, response.id),
+        updateEntities(response.id, response)
+      );
+    },
+    (error) => {
+      todosStore.update(deleteEntities(tempId));
+      // handle error
+    }
+  );
+}
+```
 
 ### `deleteEntities`
 

--- a/packages/entities/src/lib/__snapshots__/update.mutation.spec.ts.snap
+++ b/packages/entities/src/lib/__snapshots__/update.mutation.spec.ts.snap
@@ -30,6 +30,21 @@ Object {
 }
 `;
 
+exports[`update UpdateEntitiesIds should update entity after changing the id: id updated true, completed true 1`] = `
+Object {
+  "entities": Object {
+    "2": Object {
+      "completed": true,
+      "id": 2,
+      "title": "todo 1",
+    },
+  },
+  "ids": Array [
+    2,
+  ],
+}
+`;
+
 exports[`update UpdateEntitiesIds should update multiple ids: ids updated false 1`] = `
 Object {
   "entities": Object {

--- a/packages/entities/src/lib/__snapshots__/update.mutation.spec.ts.snap
+++ b/packages/entities/src/lib/__snapshots__/update.mutation.spec.ts.snap
@@ -15,21 +15,6 @@ Object {
 }
 `;
 
-exports[`update Upsert should merge fields on update: merged entity with completed: true 1`] = `
-Object {
-  "entities": Object {
-    "1": Object {
-      "completed": true,
-      "id": 1,
-      "title": "todo 1",
-    },
-  },
-  "ids": Array [
-    1,
-  ],
-}
-`;
-
 exports[`update Upsert should update the entity if it has the same id: updated entity with completed: true 1`] = `
 Object {
   "entities": Object {
@@ -101,7 +86,7 @@ Object {
 }
 `;
 
-exports[`update UpsertById should update add the missing entities and update existing: two entities, 1: title "elf", 2: title "todo 2" 1`] = `
+exports[`update UpsertById should add the missing entities and update existing: two entities, 1: title "elf", 2: title "todo 2" 1`] = `
 Object {
   "entities": Object {
     "1": Object {
@@ -151,6 +136,36 @@ Object {
   },
   "UIIds": Array [
     1,
+    2,
+  ],
+}
+`;
+
+exports[`update should support id update: id updated false 1`] = `
+Object {
+  "entities": Object {
+    "1": Object {
+      "completed": false,
+      "id": 1,
+      "title": "todo 1",
+    },
+  },
+  "ids": Array [
+    1,
+  ],
+}
+`;
+
+exports[`update should support id update: id updated true 1`] = `
+Object {
+  "entities": Object {
+    "2": Object {
+      "completed": false,
+      "id": 2,
+      "title": "todo 1",
+    },
+  },
+  "ids": Array [
     2,
   ],
 }

--- a/packages/entities/src/lib/__snapshots__/update.mutation.spec.ts.snap
+++ b/packages/entities/src/lib/__snapshots__/update.mutation.spec.ts.snap
@@ -1,5 +1,117 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`update UpdateEntitiesIds should support id update: id updated false 1`] = `
+Object {
+  "entities": Object {
+    "1": Object {
+      "completed": false,
+      "id": 1,
+      "title": "todo 1",
+    },
+  },
+  "ids": Array [
+    1,
+  ],
+}
+`;
+
+exports[`update UpdateEntitiesIds should support id update: id updated true 1`] = `
+Object {
+  "entities": Object {
+    "2": Object {
+      "completed": false,
+      "id": 2,
+      "title": "todo 1",
+    },
+  },
+  "ids": Array [
+    2,
+  ],
+}
+`;
+
+exports[`update UpdateEntitiesIds should update multiple ids: ids updated false 1`] = `
+Object {
+  "entities": Object {
+    "1": Object {
+      "completed": false,
+      "id": 1,
+      "title": "todo 1",
+    },
+    "2": Object {
+      "completed": false,
+      "id": 2,
+      "title": "todo 2",
+    },
+    "3": Object {
+      "completed": false,
+      "id": 3,
+      "title": "todo 3",
+    },
+  },
+  "ids": Array [
+    1,
+    2,
+    3,
+  ],
+}
+`;
+
+exports[`update UpdateEntitiesIds should update multiple ids: ids updated true 1`] = `
+Object {
+  "entities": Object {
+    "1": Object {
+      "completed": false,
+      "id": 1,
+      "title": "todo 1",
+    },
+    "4": Object {
+      "completed": false,
+      "id": 4,
+      "title": "todo 2",
+    },
+    "5": Object {
+      "completed": false,
+      "id": 5,
+      "title": "todo 3",
+    },
+  },
+  "ids": Array [
+    1,
+    4,
+    5,
+  ],
+}
+`;
+
+exports[`update UpdateEntitiesIds should work with ref: id updated false 1`] = `
+Object {
+  "UIEntities": Object {
+    "1": Object {
+      "id": 1,
+      "open": false,
+    },
+  },
+  "UIIds": Array [
+    1,
+  ],
+}
+`;
+
+exports[`update UpdateEntitiesIds should work with ref: id updated true 1`] = `
+Object {
+  "UIEntities": Object {
+    "2": Object {
+      "id": 2,
+      "open": false,
+    },
+  },
+  "UIIds": Array [
+    2,
+  ],
+}
+`;
+
 exports[`update Upsert should add the entity if it doesn't exists: one entities 1`] = `
 Object {
   "entities": Object {
@@ -65,27 +177,6 @@ Object {
 }
 `;
 
-exports[`update UpsertById should merge updater with creator: two entities, title "elf" 1`] = `
-Object {
-  "entities": Object {
-    "1": Object {
-      "completed": false,
-      "id": 1,
-      "title": "elf",
-    },
-    "2": Object {
-      "completed": false,
-      "id": 2,
-      "title": "elf",
-    },
-  },
-  "ids": Array [
-    1,
-    2,
-  ],
-}
-`;
-
 exports[`update UpsertById should add the missing entities and update existing: two entities, 1: title "elf", 2: title "todo 2" 1`] = `
 Object {
   "entities": Object {
@@ -98,6 +189,27 @@ Object {
       "completed": false,
       "id": 2,
       "title": "todo 2",
+    },
+  },
+  "ids": Array [
+    1,
+    2,
+  ],
+}
+`;
+
+exports[`update UpsertById should merge updater with creator: two entities, title "elf" 1`] = `
+Object {
+  "entities": Object {
+    "1": Object {
+      "completed": false,
+      "id": 1,
+      "title": "elf",
+    },
+    "2": Object {
+      "completed": false,
+      "id": 2,
+      "title": "elf",
     },
   },
   "ids": Array [
@@ -136,36 +248,6 @@ Object {
   },
   "UIIds": Array [
     1,
-    2,
-  ],
-}
-`;
-
-exports[`update should support id update: id updated false 1`] = `
-Object {
-  "entities": Object {
-    "1": Object {
-      "completed": false,
-      "id": 1,
-      "title": "todo 1",
-    },
-  },
-  "ids": Array [
-    1,
-  ],
-}
-`;
-
-exports[`update should support id update: id updated true 1`] = `
-Object {
-  "entities": Object {
-    "2": Object {
-      "completed": false,
-      "id": 2,
-      "title": "todo 1",
-    },
-  },
-  "ids": Array [
     2,
   ],
 }

--- a/packages/entities/src/lib/update.mutation.spec.ts
+++ b/packages/entities/src/lib/update.mutation.spec.ts
@@ -12,6 +12,7 @@ import {
   updateAllEntities,
   updateEntities,
   updateEntitiesByPredicate,
+  updateEntitiesIds,
   upsertEntities,
   upsertEntitiesById,
 } from './update.mutation';
@@ -62,13 +63,6 @@ describe('update', () => {
     toMatchSnapshot(expect, store, 'completed false');
     store.update(updateAllEntities({ completed: true }));
     toMatchSnapshot(expect, store, 'completed true');
-  });
-
-  it('should support id update', () => {
-    store.update(addEntities([createTodo(1)]));
-    toMatchSnapshot(expect, store, 'id updated false');
-    store.update(updateEntities(1, { id: 2 }));
-    toMatchSnapshot(expect, store, 'id updated true');
   });
 
   it('should work with ref', () => {
@@ -194,6 +188,37 @@ describe('update', () => {
       const sameIds = store.getValue().ids;
 
       expect(ids).toBe(sameIds);
+    });
+  });
+
+  describe('UpdateEntitiesIds', () => {
+    it('should support id update', () => {
+      store.update(addEntities([createTodo(1)]));
+      toMatchSnapshot(expect, store, 'id updated false');
+      store.update(updateEntitiesIds(1, 2));
+      toMatchSnapshot(expect, store, 'id updated true');
+    });
+
+    it('should update multiple ids', () => {
+      store.update(addEntities([createTodo(1), createTodo(2), createTodo(3)]));
+      toMatchSnapshot(expect, store, 'ids updated false');
+      store.update(updateEntitiesIds([2, 3], [4, 5]));
+      toMatchSnapshot(expect, store, 'ids updated true');
+    });
+
+    it('should throw if new id already exists in the store', () => {
+      store.update(addEntities([createTodo(1), createTodo(2)]));
+      expect(() => {
+        store.update(updateEntitiesIds(1, 2));
+      }).toThrow();
+    });
+
+    it('should work with ref', () => {
+      const store = createUIEntityStore();
+      store.update(addEntities([createUITodo(1)], { ref: UIEntitiesRef }));
+      toMatchSnapshot(expect, store, 'id updated false');
+      store.update(updateEntitiesIds(1, 2, { ref: UIEntitiesRef }));
+      toMatchSnapshot(expect, store, 'id updated true');
     });
   });
 });

--- a/packages/entities/src/lib/update.mutation.spec.ts
+++ b/packages/entities/src/lib/update.mutation.spec.ts
@@ -7,6 +7,7 @@ import {
   toMatchSnapshot,
 } from '@ngneat/elf-mocks';
 import { addEntities } from './add.mutation';
+import { UIEntitiesRef } from './entity.state';
 import {
   updateAllEntities,
   updateEntities,
@@ -14,8 +15,6 @@ import {
   upsertEntities,
   upsertEntitiesById,
 } from './update.mutation';
-import { UIEntitiesRef } from './entity.state';
-import { getEntity } from '..';
 
 describe('update', () => {
   let store: ReturnType<typeof createEntitiesStore>;
@@ -65,6 +64,13 @@ describe('update', () => {
     toMatchSnapshot(expect, store, 'completed true');
   });
 
+  it('should support id update', () => {
+    store.update(addEntities([createTodo(1)]));
+    toMatchSnapshot(expect, store, 'id updated false');
+    store.update(updateEntities(1, { id: 2 }));
+    toMatchSnapshot(expect, store, 'id updated true');
+  });
+
   it('should work with ref', () => {
     const store = createUIEntityStore();
     store.update(
@@ -111,7 +117,7 @@ describe('update', () => {
       toMatchSnapshot(expect, store, 'one entity, title "elf"');
     });
 
-    it('should update add the missing entities and update existing', () => {
+    it('should add the missing entities and update existing', () => {
       const store = createEntitiesStore();
       store.update(
         addEntities([createTodo(1)]),
@@ -165,22 +171,9 @@ describe('update', () => {
       store.update(addEntities([todo]));
 
       // update the todo
-      todo.completed = true;
-      store.update(upsertEntities([todo]));
-
-      toMatchSnapshot(expect, store, 'updated entity with completed: true');
-    });
-
-    it(`should merge fields on update`, () => {
-      const store = createEntitiesStore();
-
-      const todo = createTodo(1);
-      store.update(addEntities([todo]));
-
-      // update the todo
       store.update(upsertEntities([{ id: 1, completed: true }]));
 
-      toMatchSnapshot(expect, store, 'merged entity with completed: true');
+      toMatchSnapshot(expect, store, 'updated entity with completed: true');
     });
 
     it('should work with ref', () => {

--- a/packages/entities/src/lib/update.mutation.spec.ts
+++ b/packages/entities/src/lib/update.mutation.spec.ts
@@ -220,5 +220,14 @@ describe('update', () => {
       store.update(updateEntitiesIds(1, 2, { ref: UIEntitiesRef }));
       toMatchSnapshot(expect, store, 'id updated true');
     });
+
+    it('should update entity after changing the id', () => {
+      store.update(addEntities([createTodo(1)]));
+      store.update(
+        updateEntitiesIds(1, 2),
+        updateEntities(2, { completed: true })
+      );
+      toMatchSnapshot(expect, store, 'id updated true, completed true');
+    });
   });
 });

--- a/packages/entities/src/lib/update.mutation.ts
+++ b/packages/entities/src/lib/update.mutation.ts
@@ -249,13 +249,13 @@ export function upsertEntities<
  *
  * @example
  *
- * // update single entity id
+ * // Update a single entity id
  * store.update(updateEntitiesIds(1, 2));
  *
- * // update multiple entities ids
+ * // Update multiple entities ids
  * store.update(updateEntitiesIds([1, 2], [10, 20]));
  *
- * // update entity id using a custom ref
+ * // Update entity id using a custom ref
  * store.update(updateEntitiesIds(1, 2, { ref: UIEntitiesRef }));
  *
  */
@@ -296,7 +296,7 @@ export function updateEntitiesIds<
       Reflect.deleteProperty(updatedEntities, oldVal);
     }
 
-    const updatedStateIds: getIdType<S, Ref>[] = [...state[ref.idsKey]];
+    const updatedStateIds: getIdType<S, Ref>[] = state[ref.idsKey].slice();
     let processedIds = 0;
 
     for (let i = 0; i < updatedStateIds.length; i++) {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngneat/elf/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
id update via `updateEntities` is not supported

Issue Number: #146 

## What is the new behavior?
id update via `updateEntities` is supported

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
The `updateStateIds` function could have been less verbose - I could have used a simple `map`. However, I wanted to optimize the loop and break out from it as soon as ids are updated.

There was no need to update `upsertEntities` since its syntax does not support updating ids. The `upsertEntitiesById` worked out of the box since it uses `updateEntities` internally.