### PR TITLE
docs: fixes incorrect number of parameters in `withRequestsCache`

### DIFF
--- a/docs/docs/features/requests/requests-cache.mdx
+++ b/docs/docs/features/requests/requests-cache.mdx
@@ -27,7 +27,7 @@ const todosStore = createStore(
   withEntities<Todo>(),
   // You can pass the keys type
   // highlight-next-line
-  withRequestsCache<`todo-${string}`>()
+  withRequestsCache<'todo'|'todo-${string}'>()
 );
 ```
 

--- a/docs/docs/features/requests/requests-cache.mdx
+++ b/docs/docs/features/requests/requests-cache.mdx
@@ -27,7 +27,7 @@ const todosStore = createStore(
   withEntities<Todo>(),
   // You can pass the keys type
   // highlight-next-line
-  withRequestsCache<`todos`, `todo-${string}`>()
+  withRequestsCache<`todo-${string}`>()
 );
 ```
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngneat/elf/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
according to docs, `withRequestsCache` accepts two parameters like `withRequestsCache<'todos','todo-${string}'>()`, while the API accepts only one parameter.

Issue Number: N/A

## What is the new behavior?
This PR updates the docs to sync with API.


## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
