### PR TITLE
fix(active): delete entity should also remove active id

### DIFF
--- a/packages/entities/src/lib/active/active.spec.ts
+++ b/packages/entities/src/lib/active/active.spec.ts
@@ -2,6 +2,8 @@ import { createState, Store } from '@ngneat/elf';
 import {
   addActiveIds,
   addEntities,
+  deleteAllEntities,
+  deleteEntities,
   entitiesPropsFactory,
   getActiveEntities,
   getActiveEntity,
@@ -20,6 +22,7 @@ import {
   withActiveIds,
 } from './active';
 import { expectTypeOf } from 'expect-type';
+import { createTodo, toMatchSnapshot } from '@ngneat/elf-mocks';
 
 describe('activeId', () => {
   it('should select the active entity', () => {
@@ -118,6 +121,20 @@ describe('activeId', () => {
     expectTypeOf(activeRefEntity).toEqualTypeOf<
       { id: number; name: string } | undefined
     >();
+  });
+
+  it('should delete active id on entity removal', () => {
+    const { state, config } = createState(
+      withEntities<{ id: number; title: string }>(),
+      withActiveId()
+    );
+    const store = new Store({ state, config, name: '' });
+
+    store.update(addEntities([createTodo(1), createTodo(2)]));
+    store.update(setActiveId(1));
+    toMatchSnapshot(expect, store, 'should have two entities and one active');
+    store.update(deleteEntities(1));
+    toMatchSnapshot(expect, store, 'should delete one entity and one active');
   });
 });
 
@@ -225,5 +242,47 @@ describe('activeIds', () => {
     expectTypeOf(activeRefEntities).toEqualTypeOf<
       { id: number; name: string }[]
     >();
+  });
+
+  it('should delete active id on entity removal', () => {
+    const { state, config } = createState(
+      withEntities<{ id: number; title: string }>(),
+      withActiveIds()
+    );
+    const store = new Store({ state, config, name: '' });
+
+    store.update(
+      addEntities([createTodo(1), createTodo(2), createTodo(3), createTodo(4)])
+    );
+    store.update(setActiveIds([1, 3]));
+    toMatchSnapshot(expect, store, 'should have four entities and two active');
+    store.update(deleteEntities([1, 4]));
+    toMatchSnapshot(expect, store, 'should delete two entity and one active');
+    store.update(deleteEntities([3]));
+    toMatchSnapshot(expect, store, 'should delete one entity and one active');
+  });
+
+  it('should delete all active ids on store clear', () => {
+    const { state, config } = createState(
+      withEntities<{ id: number; title: string }>(),
+      withActiveIds()
+    );
+    const store = new Store({ state, config, name: '' });
+
+    store.update(
+      addEntities([createTodo(1), createTodo(2), createTodo(3), createTodo(4)])
+    );
+    store.update(setActiveIds([1, 3, 4]));
+    toMatchSnapshot(
+      expect,
+      store,
+      'should have four entities and three active'
+    );
+    store.update(deleteAllEntities());
+    toMatchSnapshot(
+      expect,
+      store,
+      'should delete four entity and three active'
+    );
   });
 });

--- a/packages/entities/src/lib/delete.mutation.ts
+++ b/packages/entities/src/lib/delete.mutation.ts
@@ -8,7 +8,7 @@ import {
   getIdType,
   ItemPredicate,
 } from './entity.state';
-import { OrArray, Reducer, coerceArray } from '@ngneat/elf';
+import { coerceArray, OrArray, Reducer } from '@ngneat/elf';
 import { findIdsByPredicate } from './entity.utils';
 
 /**
@@ -40,7 +40,15 @@ export function deleteEntities<
 
     for (const id of idsToRemove) {
       Reflect.deleteProperty(newEntities, id);
+      state.activeId === id && Reflect.set(state, 'activeId', undefined);
     }
+
+    state.activeIds &&
+      Reflect.set(
+        state,
+        'activeIds',
+        state.activeIds.filter((id: string) => !idsToRemove.includes(id))
+      );
 
     return {
       ...state,
@@ -96,6 +104,9 @@ export function deleteAllEntities<
 >(options: BaseEntityOptions<Ref> = {}): Reducer<S> {
   return function reducer(state: S) {
     const { ref: { idsKey, entitiesKey } = defaultEntitiesRef } = options;
+
+    state.activeId && Reflect.set(state, 'activeId', undefined);
+    state.activeIds && Reflect.set(state, 'activeIds', []);
 
     return {
       ...state,


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x ] The commit message follows our guidelines: https://github.com/ngneat/elf/blob/master/CONTRIBUTING.md#commit
- [x ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

When removing an entity that its id set as active, the active id doesn't delete as well.

Issue Number: N/A

## What is the new behavior?

When removing an entity that its id set as active it should remove the active id as well.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
