### PR TITLE
fix(store): make `with`prop primarily use initial value passed to it rather than one passed to propsFactory

### DIFF
--- a/packages/store/src/lib/props-factory.spec.ts
+++ b/packages/store/src/lib/props-factory.spec.ts
@@ -12,6 +12,7 @@ import {
   propsArrayFactory,
 } from './props-array-factory';
 import { expectTypeOf } from 'expect-type';
+import { createStore } from './create-store';
 
 type StatusValue = Record<string | number, StatusState>;
 type StatusState = 'pending' | 'success' | 'error';
@@ -97,6 +98,27 @@ describe('propsFactory', () => {
     store.update(setRequestsStatus((state) => state.requestsStatus));
 
     expect(spy).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('propsFactory with initial value passed to `with` prop', () => {
+  const { withRequestsStatus, updateRequestsStatus, resetRequestsStatus } =
+    propsFactory('requestsStatus', {
+      initialValue: {} as StatusValue,
+    });
+
+  const initialValue: StatusValue = { 1: 'pending' };
+  const store = createStore({ name: '' }, withRequestsStatus(initialValue));
+
+  it('should work', () => {
+    expect(store.getValue()).toEqual({ requestsStatus: initialValue });
+  });
+
+  it('should reset', () => {
+    store.update(updateRequestsStatus({ 1: 'success' }));
+    expect(store.getValue()).toEqual({ requestsStatus: { 1: 'success' } });
+    store.update(resetRequestsStatus());
+    expect(store.getValue()).toEqual({ requestsStatus: initialValue });
   });
 });
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngneat/elf/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: https://github.com/ngneat/elf/issues/238

## What is the new behavior?

## Does this PR introduce a breaking change?

```
[x] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
