### PR TITLE
docs(general): provide oop example that matches cli output and fix functional example

### DIFF
--- a/docs/docs/features/requests/requests-status.mdx
+++ b/docs/docs/features/requests/requests-status.mdx
@@ -30,7 +30,7 @@ const todosStore = createStore(
   withEntities<Todo>(),
   // You can pass the keys type
   // highlight-next-line
-  withRequestsStatus<`todos`, `todo-${string}`>()
+  withRequestsStatus<`todos` | `todo-${string}`>()
 );
 ```
 

--- a/docs/docs/repository.mdx
+++ b/docs/docs/repository.mdx
@@ -29,45 +29,28 @@ The Repository pattern provides 2 main benefits:
 1. Using the pattern, you can replace your data store without changing your business code.
 2. It encourages you to implement all store operations in one place, making your code more reusable and easy to find.
 
-If working in Angular, you can also use the object-oriented programming (OOP) approach:
+You can also use the object-oriented programming (OOP) approach:
 
 ```ts title="auth.repository.ts"
-import { createStore, select, withProps } from '@ngneat/elf';
-import { Injectable } from '@angular/core';
-import { Observable } from 'rxjs';
+import { createStore, withProps, select } from '@ngneat/elf';
 
 interface AuthProps {
   user: { id: string } | null;
 }
 
-@Injectable({ providedIn: 'root' })
+const authStore = createStore(
+  { name: 'auth' },
+  withProps<AuthProps>({ user: null })
+);
+
 export class AuthRepository {
-  user$: Observable<AuthProps['user']>;
+  user$ = authStore.pipe(select((state) => state.user));
 
-  private store;
-
-  constructor() {
-    this.store = this.createStore();
-
-    this.user$ = this.store.pipe(select((state) => state.user));
-  }
-
-  public updateUser(user: AuthProps['user']) {
-    this.store.update((state) => {
-      return {
-        ...state,
-        user,
-      };
-    });
-  }
-
-  private createStore(): typeof store {
-    const store = createStore(
-      { name: 'auth' },
-      withProps<AuthProps>({ user: null })
-    );
-
-    return store;
+  updateUser(user: AuthProps['user']) {
+    authStore.update((state) => ({
+      ...state,
+      user,
+    }));
   }
 }
 ```

--- a/docs/docs/repository.mdx
+++ b/docs/docs/repository.mdx
@@ -9,7 +9,10 @@ interface AuthProps {
   user: { id: string } | null;
 }
 
-const authStore = createStore({ name }, withProps<AuthProps>({ user: null }));
+const authStore = createStore(
+  { name: 'auth' },
+  withProps<AuthProps>({ user: null })
+);
 
 export const user$ = authStore.pipe(select((state) => state.user));
 
@@ -26,21 +29,45 @@ The Repository pattern provides 2 main benefits:
 1. Using the pattern, you can replace your data store without changing your business code.
 2. It encourages you to implement all store operations in one place, making your code more reusable and easy to find.
 
-You can also use the `OOP` approach:
+If working in Angular, you can also use the object-oriented programming (OOP) approach:
 
 ```ts title="auth.repository.ts"
-// ...
+import { createStore, select, withProps } from '@ngneat/elf';
+import { Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
 
-const authStore = createStore({ name }, withProps<AuthProps>({ user: null }));
+interface AuthProps {
+  user: { id: string } | null;
+}
 
+@Injectable({ providedIn: 'root' })
 export class AuthRepository {
-  user$ = authStore.pipe(select((state) => state.user));
+  user$: Observable<AuthProps['user']>;
 
-  updateUser(user: AuthProps['user']) {
-    authStore.update((state) => ({
-      ...state,
-      user,
-    }));
+  private store;
+
+  constructor() {
+    this.store = this.createStore();
+
+    this.user$ = this.store.pipe(select((state) => state.user));
+  }
+
+  public updateUser(user: AuthProps['user']) {
+    this.store.update((state) => {
+      return {
+        ...state,
+        user,
+      };
+    });
+  }
+
+  private createStore(): typeof store {
+    const store = createStore(
+      { name: 'auth' },
+      withProps<AuthProps>({ user: null })
+    );
+
+    return store;
   }
 }
 ```


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngneat/elf/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
Documentation for the repository pattern has the current behavior:
1.  Functional example calls `createStore` with `{name}` with no name set.  
2. OOP acronym is not defined.  Learner bias that everyone knows that OOP is Object-oriented programming.  Most do, but such little effort to serve all.  ❤️ 
3. OOP example is not complete:  Instead, you get `// ...`.  Approach bias.  Functional fans get a complete example.  OOP fans do not.    Not friendly to your Angular friends.
4. OOP example does not match the awesome output produced by the CLI when `repoTemplate` option is set to `class` for `repo` command.

Issue Number: N/A

## What is the new behavior?

Documentation for the repository pattern now has the following behavior:
1. Functional example calls `createStore` with `{name: 'auth'}`.
2. OOP acronym is defined once with the following text: "object-oriented programming (OOP)"
3. OOP example is equally complete as the functional example.
4. OOP example now matches the awesome output produced by the CLI.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
