### PR TITLE
fix(persist-state): added missing export "MaybeAsync" type

### DIFF
--- a/packages/persist-state/src/index.ts
+++ b/packages/persist-state/src/index.ts
@@ -3,5 +3,6 @@ export {
   StateStorage,
   localStorageStrategy,
   sessionStorageStrategy,
+  MaybeAsync,
 } from './lib/storage';
 export { excludeKeys } from './lib/exclude-keys';

--- a/packages/persist-state/src/index.ts
+++ b/packages/persist-state/src/index.ts
@@ -3,6 +3,6 @@ export {
   StateStorage,
   localStorageStrategy,
   sessionStorageStrategy,
-  MaybeAsync,
+  Async,
 } from './lib/storage';
 export { excludeKeys } from './lib/exclude-keys';

--- a/packages/persist-state/src/lib/storage.ts
+++ b/packages/persist-state/src/lib/storage.ts
@@ -1,15 +1,13 @@
 import { Observable, of } from 'rxjs';
 
-export type MaybeAsync<T> = Promise<T> | Observable<T>;
+export type Async<T> = Promise<T> | Observable<T>;
 
 export interface StateStorage {
-  getItem<T extends Record<string, any>>(
-    key: string
-  ): MaybeAsync<T | undefined>;
+  getItem<T extends Record<string, any>>(key: string): Async<T | undefined>;
 
-  setItem(key: string, value: Record<string, any>): MaybeAsync<boolean>;
+  setItem(key: string, value: Record<string, any>): Async<boolean>;
 
-  removeItem(key: string): MaybeAsync<boolean>;
+  removeItem(key: string): Async<boolean>;
 }
 
 function createStorage(storage: Storage | undefined): StateStorage | undefined {

--- a/packages/persist-state/src/lib/storage.ts
+++ b/packages/persist-state/src/lib/storage.ts
@@ -1,6 +1,6 @@
 import { Observable, of } from 'rxjs';
 
-type MaybeAsync<T> = Promise<T> | Observable<T>;
+export type MaybeAsync<T> = Promise<T> | Observable<T>;
 
 export interface StateStorage {
   getItem<T extends Record<string, any>>(


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngneat/elf/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

MaybeAsync type is not exported from @ngneat/elf-persist-state

## What is the new behavior?

MaybeAsync is exported from @ngneat/elf-persist-state

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

## Other information

It might be useful for a custom StateStorage, since it's required to return this type in the implementation