### PR TITLE
fix(pagination): export PaginationState to fix typescript-error

### DIFF
--- a/packages/pagination/src/lib/pagination.ts
+++ b/packages/pagination/src/lib/pagination.ts
@@ -26,7 +26,7 @@ export interface PaginationData<IdType extends number | string = number> {
   currentPage: IdType;
 }
 
-interface PaginationState<IdType extends number | string = number> {
+export interface PaginationState<IdType extends number | string = number> {
   pagination: {
     pages: Record<IdType, IdType[]>;
   } & PaginationData<IdType>;


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngneat/elf/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[ ] Feature
[x] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

Typescript error when using `withPagination()` in a store:
`Exported variable 'ProductStore' has or is using name 'PaginationState' from external module "[PATH]/node_modules/@ngneat/elf-pagination/lib/pagination" but cannot be named.ts(4023)`

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

No more TS-error

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
