### PR TITLE
docs(contributing): fix broken link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,6 +3,7 @@
 🙏 We would ❤️ for you to contribute to Elf and help make it even better than it is today!
 
 ## Developing
+
 - Run `npm i` on both the root and `packages/cli`
 - Run specs: nx test `<package-name>`
 - Run build: nx build `<package-name>`
@@ -40,7 +41,7 @@ to read on GitHub as well as in various git tools.
 
 The footer should contain a [closing reference to an issue](https://help.github.com/articles/closing-issues-via-commit-messages/) if any.
 
-Samples: (even more [samples](https://github.com/angular/angular/commits/master))
+Samples: (even more [samples](https://github.com/angular/angular/commits/main))
 
 ```
 docs(changelog): update changelog to beta.5


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngneat/elf/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

Angular repo switched from `master` to `main` and the link became broken

Issue Number: N/A

## What is the new behavior?

The link to commit message examples is working

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

Also the MD formatter (probably Prettier) added a new line after H2 which is more compliant with the standard, I guess. I think there is no harm to keep it to prevent it from being added again at least.