### PR TITLE
feat(entities): enable updateEntities to delete

### DIFF
--- a/packages/entities/src/lib/__snapshots__/update.mutation.spec.ts.snap
+++ b/packages/entities/src/lib/__snapshots__/update.mutation.spec.ts.snap
@@ -268,6 +268,92 @@ Object {
 }
 `;
 
+exports[`update should delete when DELETE_SYMBOL is returned from the callback: 2 entities deleted 1`] = `
+Object {
+  "entities": Object {},
+  "ids": Array [],
+}
+`;
+
+exports[`update should delete when DELETE_SYMBOL is returned from the callback: 2 entities present 1`] = `
+Object {
+  "entities": Object {
+    "1": Object {
+      "completed": false,
+      "id": 1,
+      "title": "todo 1",
+    },
+    "2": Object {
+      "completed": false,
+      "id": 2,
+      "title": "todo 2",
+    },
+  },
+  "ids": Array [
+    1,
+    2,
+  ],
+}
+`;
+
+exports[`update should delete when DELETE_SYMBOL is used instead of partial object: entity absent 1`] = `
+Object {
+  "entities": Object {},
+  "ids": Array [],
+}
+`;
+
+exports[`update should delete when DELETE_SYMBOL is used instead of partial object: entity present 1`] = `
+Object {
+  "entities": Object {
+    "1": Object {
+      "completed": false,
+      "id": 1,
+      "title": "todo 1",
+    },
+  },
+  "ids": Array [
+    1,
+  ],
+}
+`;
+
+exports[`update should either update or delete based on value returned from the callback: 1 entity present and it is completed 1`] = `
+Object {
+  "entities": Object {
+    "2": Object {
+      "completed": true,
+      "id": 2,
+      "title": "todo 2",
+    },
+  },
+  "ids": Array [
+    2,
+  ],
+}
+`;
+
+exports[`update should either update or delete based on value returned from the callback: 2 entities present, entity 1 is completed 1`] = `
+Object {
+  "entities": Object {
+    "1": Object {
+      "completed": true,
+      "id": 1,
+      "title": "todo 1",
+    },
+    "2": Object {
+      "completed": false,
+      "id": 2,
+      "title": "todo 2",
+    },
+  },
+  "ids": Array [
+    1,
+    2,
+  ],
+}
+`;
+
 exports[`update should update all: completed false 1`] = `
 Object {
   "entities": Object {

--- a/packages/entities/src/lib/update.mutation.spec.ts
+++ b/packages/entities/src/lib/update.mutation.spec.ts
@@ -9,6 +9,7 @@ import {
 import { addEntities } from './add.mutation';
 import { UIEntitiesRef } from './entity.state';
 import {
+  DELETE_ENTITY,
   updateAllEntities,
   updateEntities,
   updateEntitiesByPredicate,
@@ -45,6 +46,32 @@ describe('update', () => {
       updateEntities(1, (todo) => ({ ...todo, completed: !todo.completed }))
     );
     toMatchSnapshot(expect, store, 'completed true');
+  });
+
+  it('should delete when DELETE_ENTITY is used instead of partial object', () => {
+    store.update(addEntities(createTodo(1)));
+    toMatchSnapshot(expect, store, 'entity present');
+    store.update(updateEntities(1, DELETE_ENTITY));
+    toMatchSnapshot(expect, store, 'entity deleted');
+  });
+
+  it('should delete when DELETE_ENTITY is returned from the callback', () => {
+    store.update(addEntities([createTodo(1), createTodo(2)]));
+    toMatchSnapshot(expect, store, '2 entities present');
+    store.update(updateEntities([1, 2], () => DELETE_ENTITY));
+    toMatchSnapshot(expect, store, '2 entities deleted');
+  });
+
+  it('should either update or delete based on value returned from the callback', () => {
+    store.update(addEntities([createTodo(1), createTodo(2)]));
+    store.update(updateEntities(1, { completed: true }));
+    toMatchSnapshot(expect, store, '2 entities present, entity 1 is completed');
+    store.update(
+      updateEntities([1, 2], (todo) =>
+        todo.completed ? DELETE_ENTITY : { ...todo, completed: true }
+      )
+    );
+    toMatchSnapshot(expect, store, '1 entity present and it is completed');
   });
 
   it('should update by predicate', () => {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngneat/elf/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

It's impossible to conditionally delete an entity during the update

Discussion: https://github.com/ngneat/elf/discussions/279

## What is the new behavior?

Returning `DELETE_ENTITY` from the updater or as the updater will remove that entity

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

## Other information

This is WIP draft PR to discuss main points while changing the basic `updateEntities` mutation. The rest of `update` family will be changes after we agree on the main points.

The decisions for now:
* use the word `delete` (not `remove`) because there is already public API mutation called `delete`
* consider existing `delete` mutation as a primitive operation - meaning update will use it for removing rather than opposite or moving the shared remove functionality to some utility function
* allow 1 extra JS Object copy in case if some entities should be removed during the update (considering the JS Object copy to be a "cheap" operation)
* allow to pass `DELETE_ENTITY` as an argument too (not only as a result of a callback) (in that case the result will be equal to called `delete` directly and that will be cheaper, so it's the question first if such API flexibility is needed?) (if this will remain, with a simple comparison of the argument the call can be redirected to the `delete` and then it will have the same performance characteristic as the primitive operation)
