### PR TITLE
feat(entities): add draft mutateEntities

### DIFF
--- a/packages/entities/src/lib/__snapshots__/update.mutation.spec.ts.snap
+++ b/packages/entities/src/lib/__snapshots__/update.mutation.spec.ts.snap
@@ -268,6 +268,42 @@ Object {
 }
 `;
 
+exports[`update mutateEntities should either update or delete based on the reducer returned from the callback: 2 entities present, entity 1 is completed 1`] = `
+Object {
+  "entities": Object {
+    "1": Object {
+      "completed": true,
+      "id": 1,
+      "title": "todo 1",
+    },
+    "2": Object {
+      "completed": false,
+      "id": 2,
+      "title": "todo 2",
+    },
+  },
+  "ids": Array [
+    1,
+    2,
+  ],
+}
+`;
+
+exports[`update mutateEntities should either update or delete based on the reducer returned from the callback: only entity 2 is present and it is completed 1`] = `
+Object {
+  "entities": Object {
+    "2": Object {
+      "completed": true,
+      "id": 2,
+      "title": "todo 2",
+    },
+  },
+  "ids": Array [
+    2,
+  ],
+}
+`;
+
 exports[`update should update all: completed false 1`] = `
 Object {
   "entities": Object {

--- a/packages/entities/src/lib/update.mutation.spec.ts
+++ b/packages/entities/src/lib/update.mutation.spec.ts
@@ -7,8 +7,10 @@ import {
   toMatchSnapshot,
 } from '@ngneat/elf-mocks';
 import { addEntities } from './add.mutation';
+import { deleteEntities } from './delete.mutation';
 import { UIEntitiesRef } from './entity.state';
 import {
+  mutateEntities,
   updateAllEntities,
   updateEntities,
   updateEntitiesByPredicate,
@@ -228,6 +230,30 @@ describe('update', () => {
         updateEntities(2, { completed: true })
       );
       toMatchSnapshot(expect, store, 'id updated true, completed true');
+    });
+  });
+
+  describe('mutateEntities', () => {
+    it('should either update or delete based on the reducer returned from the callback', () => {
+      store.update(addEntities([createTodo(1), createTodo(2)]));
+      store.update(updateEntities(1, { completed: true }));
+      toMatchSnapshot(
+        expect,
+        store,
+        '2 entities present, entity 1 is completed'
+      );
+      store.update(
+        mutateEntities([1, 2], (id, todo) =>
+          todo?.completed
+            ? deleteEntities(id)
+            : updateEntities(id, { completed: true })
+        )
+      );
+      toMatchSnapshot(
+        expect,
+        store,
+        'only entity 2 is present and it is completed'
+      );
     });
   });
 });

--- a/packages/entities/src/lib/update.mutation.ts
+++ b/packages/entities/src/lib/update.mutation.ts
@@ -325,3 +325,27 @@ export function updateEntitiesIds<
     };
   };
 }
+
+export type MutateFn<State, Entity, Id> = (
+  id: Id,
+  maybeEntity: Entity | undefined
+) => Reducer<State>;
+
+export function mutateEntities<
+  S extends EntitiesState<Ref>,
+  M extends MutateFn<S, getEntityType<S, Ref>, getIdType<S, Ref>>,
+  Ref extends EntitiesRef = DefaultEntitiesRef
+>(
+  ids: OrArray<getIdType<S, Ref>>,
+  mutator: M,
+  options: BaseEntityOptions<Ref> = {}
+): Reducer<S> {
+  return function (state, context) {
+    const { ref: { entitiesKey } = defaultEntitiesRef } = options;
+
+    return coerceArray(ids).reduce((prevState, id) => {
+      let entity = prevState[entitiesKey][id];
+      return mutator(id, entity)(prevState, context);
+    }, state);
+  };
+}


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngneat/elf/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

It's impossible to conditionally choose a mutation operation based on some property of mutated entity

Continuation of:
* Discussion: https://github.com/ngneat/elf/discussions/279
* PR: https://github.com/ngneat/elf/pull/284

## What is the new behavior?

It's possible to conditionally choose a mutation operation based on some property of mutated entity

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
