### PR TITLE
docs(dev-tools): Add guide to show ngneat/effects in dev-tools

### DIFF
--- a/docs/docs/dev-tools.mdx
+++ b/docs/docs/dev-tools.mdx
@@ -22,6 +22,8 @@ The plugin supports the following options passed as the second function paramete
 
 `preAction` - A method that's called before each action.
 
+`actionsDispatcher` - Observable of actions. For example actions created by [@ngeat/effects](https://github.com/ngneat/effects)
+
 `postTimelineUpdate` - A function that'll be invoked after the devtools timeline updates. For example, you can run a change detection when working with Angular:
 
 ```ts
@@ -37,4 +39,39 @@ platformBrowserDynamic()
       postTimelineUpdate: () => moduleRef.injector.get(ApplicationRef).tick()
     });
 })
+```
+## Display actions from [@ngeat/effects](https://github.com/ngneat/effects)
+
+### Angular
+
+```ts
+import { EffectsNgModule, Actions } from '@ngneat/effects-ng';
+import { SampleEffects } from 'sample/sample.effect.ts';
+import { devTools } from '@ngneat/elf-devtools';
+
+export function initElfDevTools(actions: Actions) {
+  return () => {
+    devTools({
+      name: 'Sample Application',
+      actionsDispatcher: actions
+    })
+  };
+}
+
+@NgModule({
+  imports: [
+    // other modules
+    EffectsNgModule.forRoot([SampleEffects]),
+  ],
+  providers: [
+    {
+      provide: APP_INITIALIZER,
+      multi: true,
+      useFactory: initElfDevTools,
+      deps: [Actions]
+    }
+  ]
+})
+export class AppModule {
+}
 ```


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ x] The commit message follows our guidelines: https://github.com/ngneat/elf/blob/master/CONTRIBUTING.md#commit
- [ x] Tests for the changes have been added (for bug fixes / features)
- [ x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ x] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

The docs lack information on how to include a custom actions stream into the devtools.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

The docs contain a section which will describe how to include a sample actions stream of [@ngneat/effects](https://github.com/ngneat/effects) into the devtools.

The section is very angular oriented because I have no experience in react.

## Does this PR introduce a breaking change?

```
[ ] Yes
[ x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
