### PR TITLE
fix(state-history): export StateHistory to be able to use stateHistory

### DIFF
--- a/packages/state-history/src/lib/state-history.ts
+++ b/packages/state-history/src/lib/state-history.ts
@@ -15,7 +15,7 @@ type History<State> = {
   future: State[];
 };
 
-class StateHistory<T extends Store, State extends StoreValue<T>> {
+export class StateHistory<T extends Store, State extends StoreValue<T>> {
   private paused = false;
 
   private history: History<State> = {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngneat/elf/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

There is an error 
```ts
export class Repo {
   readonly stateHistory = stateHistory(store);
}


TS4029: Public property 'stateHistory' of exported class has or is using name 'StateHistory' from external module "/node_modules/@ngneat/elf-state-history/lib/state-history" but cannot be named.
```

Issue Number: N/A

## What is the new behavior?

Class `StateHistor` is exported so `stateHistory` can be properly used

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
