### PR TITLE
fix(state-history): fix `EntitiesStateHistory` to make it consider initial entities

### DIFF
--- a/docs/docs/examples/entities-state-history.ex.ts
+++ b/docs/docs/examples/entities-state-history.ex.ts
@@ -1,5 +1,6 @@
 import { createStore } from '@ngneat/elf';
 import {
+  selectAllEntities,
   withEntities,
   withUIEntities,
   UIEntitiesRef,
@@ -38,7 +39,12 @@ export const todosUIStateHistory = entitiesStateHistory(todosStore, {
   entitiesRef: UIEntitiesRef,
 });
 
-todosStore.subscribe(console.log);
+todosStore
+  .pipe(selectAllEntities())
+  .subscribe((entities) => console.log('Entities: ', entities));
+todosStore
+  .pipe(selectAllEntities({ ref: UIEntitiesRef }))
+  .subscribe((entities) => console.log('UI Entities: ', entities));
 
 todosStore.update(
   updateEntities([0, 1], { label: 'Renamed Todo' }),

--- a/packages/state-history/src/lib/entities-state-history.spec.ts
+++ b/packages/state-history/src/lib/entities-state-history.spec.ts
@@ -322,6 +322,28 @@ describe('entities state history', () => {
     expect(history.hasPast(2)).toBeFalsy();
   });
 
+  it('should work with initial entities', function () {
+    const store = createStore(
+      { name: '' },
+      withEntities<Entity>({
+        initialValue: [
+          { id: 1, label: 'first' },
+          { id: 2, label: 'second' },
+        ],
+      })
+    );
+    const history = entitiesStateHistory(store);
+
+    store.update(updateEntities([1, 2], { label: 'Renamed entity' }));
+
+    history.undo(1);
+
+    expect(store.query(getAllEntities())).toEqual([
+      { id: 1, label: 'first' },
+      { id: 2, label: 'Renamed entity' },
+    ]);
+  });
+
   it('should track only passed ids', () => {
     const store = createStore({ name: '' }, withEntities<Entity>());
     const history = entitiesStateHistory(store, { entityIds: [2] });


### PR DESCRIPTION
…h initial entities

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngneat/elf/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

Issue Number: N/A

## What is the new behavior?

`EntitiesStateHistory` didn't consider entities set as an initial value

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
