### PR TITLE
feat(dirty-check) new dirty check plugin

### DIFF
--- a/docs/docs/examples/dirty-check.ex.ts
+++ b/docs/docs/examples/dirty-check.ex.ts
@@ -1,0 +1,23 @@
+import { createStore, withProps } from '@ngneat/elf';
+import { dirtyCheck } from '@ngneat/elf-dirty-check';
+
+const todosStore = createStore(
+  { name: 'auth' },
+  withProps<{ user: string }>({
+    user: '',
+  })
+);
+
+export const dirty = dirtyCheck(todosStore);
+
+todosStore.subscribe(console.log);
+
+dirty.setHead();
+todosStore.update((state) => ({
+  ...state,
+  user: 'Elf',
+}));
+
+dirty.isDirty();
+// or
+dirty.isDirty$.subscribe(console.log);

--- a/docs/docs/features/dirty-check/dirty-check.mdx
+++ b/docs/docs/features/dirty-check/dirty-check.mdx
@@ -1,0 +1,92 @@
+# Dirty Check
+
+import index from '!!raw-loader!@site/docs/examples/dirty-check.ex';
+import { LiveDemo } from '@site/components/LiveDemo';
+
+The `dirtyCheck` function provides a convenient way for comparing state against a head revision and if it has changed it is marked as dirty.
+
+First, you need to install the package by using the CLI command `elf-cli install` and selecting the dirty-check package, or via npm:
+
+```bash
+npm i @ngneat/elf-dirty-check
+```
+
+Then, call the `dirtyCheck` method when you want to start monitoring.
+
+```ts
+import { createStore } from '@ngneat/elf';
+import { stateHistory } from '@ngneat/elf-dirty-check';
+
+const propsStore = createStore({ name }, withProps<Props>());
+
+export const dirty = dirtyCheck(propsStore);
+```
+
+As the second parameter you can pass a `DirtyCheckOptions` object, which can be used to define if you only want cetain paths to be watched or if you want to use another state compare function.
+
+<LiveDemo src={index} packages={['dirty-check']} />
+
+## API
+
+### `setHead`
+
+Sets the current state as the revision you want to compare against:
+
+```ts
+dirty.setHead();
+```
+
+### `isDirty`
+
+Check if the current state is dirty:
+
+```ts
+dirty.isDirty();
+```
+
+### `isDirty$`
+
+same as isDirty but is an observable
+
+```ts
+dirty.isDirty$.subscribe(console.log);
+```
+
+### `dispose`
+
+when you dispose of the component that instancied the dirty checker, you need to call dispose so that the subscription that is listening gets disposed.
+
+```ts
+// for example in an angular component
+ngOnInit() {
+  this.dirty = dirtyCheck(store);
+}
+
+ngOnDestroy() {
+  this.dirty.dispose();
+}
+```
+
+### `reset`
+
+Resets the dirty state and head:
+
+```ts
+dirty.reset();
+```
+
+### `pause`
+
+Stop monitoring the state changes:
+
+```ts
+dirty.pause();
+```
+
+### `resume`
+
+Continue monitoring the state changes:
+
+```ts
+dirty.resume();
+```

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,5 @@
+const { getJestProjects } = require('@nrwl/jest');
+
+module.exports = {
+  projects: getJestProjects(),
+};

--- a/packages/dirty-check/.babelrc
+++ b/packages/dirty-check/.babelrc
@@ -1,0 +1,3 @@
+{
+  "presets": [["@nrwl/web/babel", { "useBuiltIns": "usage" }]]
+}

--- a/packages/dirty-check/.eslintrc.json
+++ b/packages/dirty-check/.eslintrc.json
@@ -1,0 +1,18 @@
+{
+  "extends": ["../../.eslintrc.json"],
+  "ignorePatterns": ["!**/*"],
+  "overrides": [
+    {
+      "files": ["*.ts", "*.tsx", "*.js", "*.jsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.ts", "*.tsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.js", "*.jsx"],
+      "rules": {}
+    }
+  ]
+}

--- a/packages/dirty-check/CHANGELOG.md
+++ b/packages/dirty-check/CHANGELOG.md
@@ -1,0 +1,3 @@
+# Changelog
+
+This file was generated using [@jscutlery/semver](https://github.com/jscutlery/semver).

--- a/packages/dirty-check/README.md
+++ b/packages/dirty-check/README.md
@@ -1,0 +1,3 @@
+# @ngneat/elf-dirty-check
+
+[Docs](https://ngneat.github.io/elf/docs/features/dirty-check)

--- a/packages/dirty-check/jest.config.js
+++ b/packages/dirty-check/jest.config.js
@@ -1,0 +1,14 @@
+module.exports = {
+  displayName: 'dirty-check',
+  preset: '../../jest.preset.js',
+  globals: {
+    'ts-jest': {
+      tsconfig: '<rootDir>/tsconfig.spec.json',
+    },
+  },
+  transform: {
+    '^.+\\.[tj]sx?$': 'ts-jest',
+  },
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],
+  coverageDirectory: '../../coverage/packages/dirty-check',
+};

--- a/packages/dirty-check/package.json
+++ b/packages/dirty-check/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "@ngneat/elf-dirty-check",
+  "version": "1.0.0",
+  "description": "dirty check management for elf store",
+  "publishConfig": {
+    "access": "public"
+  },
+  "bugs": {
+    "url": "https://github.com/ngneat/elf/issues"
+  },
+  "homepage": "https://github.com/ngneat/elf#readme",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ngneat/elf"
+  },
+  "keywords": [
+    "rxjs",
+    "state management",
+    "reactive state management",
+    "js state management",
+    "reactive store",
+    "elf",
+    "dirty check"
+  ],
+  "author": {
+    "name": "Leon Radley",
+    "email": "leon@radley.se",
+    "url": "https://leon.id"
+  },
+  "sideEffects": false,
+  "peerDependencies": {
+    "@ngneat/elf-entities": "*"
+  },
+  "license": "MIT"
+}

--- a/packages/dirty-check/project.json
+++ b/packages/dirty-check/project.json
@@ -1,0 +1,58 @@
+{
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "packages/dirty-check/src",
+  "projectType": "library",
+  "targets": {
+    "build": {
+      "executor": "@nrwl/web:rollup",
+      "outputs": ["{options.outputPath}"],
+      "options": {
+        "outputPath": "dist/packages/dirty-check",
+        "updateBuildableProjectDepsInPackageJson": false,
+        "tsConfig": "packages/dirty-check/tsconfig.lib.json",
+        "project": "packages/dirty-check/package.json",
+        "entryFile": "packages/dirty-check/src/index.ts",
+        "rollupConfig": "@nrwl/react/plugins/bundle-rollup",
+        "globals": [
+          {
+            "global": "Rx",
+            "moduleId": "rxjs"
+          },
+          {
+            "global": "Rx",
+            "moduleId": "rxjs/operators"
+          }
+        ],
+        "assets": [
+          {
+            "glob": "packages/dirty-check/*.md",
+            "input": ".",
+            "output": "."
+          }
+        ]
+      }
+    },
+    "lint": {
+      "executor": "@nrwl/linter:eslint",
+      "options": {
+        "lintFilePatterns": ["packages/dirty-check/**/*.ts"]
+      },
+      "outputs": ["{options.outputFile}"]
+    },
+    "test": {
+      "executor": "@nrwl/jest:jest",
+      "outputs": ["coverage/packages/dirty-check"],
+      "options": {
+        "jestConfig": "packages/dirty-check/jest.config.ts",
+        "passWithNoTests": true
+      }
+    },
+    "version": {
+      "executor": "@jscutlery/semver:version",
+      "options": {
+        "syncVersions": false
+      }
+    }
+  },
+  "tags": []
+}

--- a/packages/dirty-check/src/index.ts
+++ b/packages/dirty-check/src/index.ts
@@ -1,0 +1,1 @@
+export * from './lib/dirty-check';

--- a/packages/dirty-check/src/lib/dirty-check.spec.ts
+++ b/packages/dirty-check/src/lib/dirty-check.spec.ts
@@ -1,0 +1,7 @@
+import { dirtyCheck } from './dirty-check';
+
+describe('dirtyCheck', () => {
+  it('should work', () => {
+    expect(dirtyCheck()).toEqual('dirty-check');
+  });
+});

--- a/packages/dirty-check/src/lib/dirty-check.spec.ts
+++ b/packages/dirty-check/src/lib/dirty-check.spec.ts
@@ -1,7 +1,112 @@
 import { dirtyCheck } from './dirty-check';
+import { createStore, setProps, withProps } from '@ngneat/elf';
 
-describe('dirtyCheck', () => {
-  it('should work', () => {
-    expect(dirtyCheck()).toEqual('dirty-check');
+interface TestProps {
+  item1?: number;
+  item2?: {
+    item21?: number;
+    item22?: {
+      item221?: number;
+    };
+  };
+  item3?: number;
+}
+
+describe('dirty check', () => {
+  const initialState: TestProps = {
+    item1: 1,
+    item2: {
+      item21: 2,
+      item22: {
+        item221: 3,
+      },
+    },
+  };
+
+  const store = createStore(
+    { name: 'test' },
+    withProps<TestProps>(initialState)
+  );
+  beforeEach(() => {
+    store.reset();
+  });
+
+  it('should not be dirty from start', () => {
+    const dirty = dirtyCheck(store);
+    expect(dirty.isDirty()).toEqual(false);
+  });
+
+  it('should set head', () => {
+    const dirty = dirtyCheck(store);
+    store.update(setProps({ item1: 2 }));
+    expect(dirty.isDirty()).toEqual(true);
+    dirty.setHead();
+    expect(dirty.isDirty()).toEqual(false);
+  });
+
+  it('should get the head', () => {
+    const dirty = dirtyCheck(store);
+    store.update(setProps({ item1: 2 }));
+    expect(dirty.getHead()).toEqual(initialState);
+  });
+
+  it('should get combined state of keys if watch is used', () => {
+    const dirty = dirtyCheck(store, {
+      watch: ['item1', 'item3'],
+    });
+    store.update(setProps({ item1: 1, item3: 3 }));
+    dirty.setHead();
+    expect(dirty.getHead()).toEqual({ item1: 1, item3: 3 });
+  });
+
+  it('should reset dirty state', () => {
+    const dirty = dirtyCheck(store);
+    store.update(setProps({ item1: 2 }));
+    expect(dirty.isDirty()).toEqual(true);
+    dirty.reset();
+    expect(dirty.isDirty()).toEqual(false);
+  });
+
+  it('should not trigger dirty if changing prop outside watch', () => {
+    const dirty = dirtyCheck(store, {
+      watch: ['item2'],
+    });
+    // should not trigger dirty state
+    store.update(setProps({ item1: 2 }));
+    expect(dirty.isDirty()).toEqual(false);
+  });
+
+  it('should trigger dirty when changing prop inside watch', () => {
+    const dirty = dirtyCheck(store, {
+      watch: ['item2'],
+    });
+    // should not trigger dirty state
+    store.update(
+      setProps((state) => ({
+        item2: {
+          ...state.item2,
+          item21: 21,
+        },
+      }))
+    );
+    expect(dirty.isDirty()).toEqual(true);
+  });
+
+  it('should set new head when using watch', () => {
+    const dirty = dirtyCheck(store, {
+      watch: ['item2'],
+    });
+    dirty.setHead();
+    store.update(
+      setProps((state) => ({
+        item2: {
+          ...state.item2,
+          item21: 21,
+        },
+      }))
+    );
+    expect(dirty.isDirty()).toEqual(true);
+    dirty.setHead();
+    expect(dirty.isDirty()).toEqual(false);
   });
 });

--- a/packages/dirty-check/src/lib/dirty-check.ts
+++ b/packages/dirty-check/src/lib/dirty-check.ts
@@ -1,3 +1,130 @@
-export function dirtyCheck(): string {
-  return 'dirty-check';
+import { Store, StoreValue } from '@ngneat/elf';
+import { BehaviorSubject, Subscription } from 'rxjs';
+import { distinctUntilChanged, filter, map } from 'rxjs/operators';
+
+export interface DirtyCheckOptions<State> {
+  /**
+   * An array of keys that should be watched checked if dirty
+   */
+  watch?: (keyof State)[];
+
+  /**
+   * Are the previous and current state the same?
+   * @param prevState previous head state
+   * @param currentState current head state
+   */
+  comparatorFn?: (
+    prevState: Partial<State> | null,
+    currentState: Partial<State>
+  ) => boolean;
+}
+
+type DirtyCheckProps<State> = {
+  head: Partial<State> | null;
+};
+
+export class DirtyCheck<T extends Store, State extends StoreValue<T>> {
+  protected options: DirtyCheckOptions<State>;
+  protected subscription: Subscription | undefined;
+  protected isDirtySubject = new BehaviorSubject(false);
+  protected paused = false;
+  protected dirtyState: DirtyCheckProps<State> = {
+    head: null,
+  };
+
+  public isDirty$ = this.isDirtySubject.asObservable().pipe(
+    filter(() => !this.paused),
+    distinctUntilChanged()
+  );
+
+  constructor(
+    protected store: T,
+    options: Partial<DirtyCheckOptions<State>> = {}
+  ) {
+    this.options = {
+      ...options,
+    };
+    if (!this.options.comparatorFn) {
+      this.options = {
+        ...this.options,
+        comparatorFn: (prevState, currentState) =>
+          JSON.stringify(prevState ?? '{}') ===
+          JSON.stringify(currentState ?? '{}'),
+      };
+    }
+    this.activate();
+  }
+
+  activate() {
+    this.subscription = this.store
+      .pipe(
+        filter(() => !this.paused),
+        map((state) => this.getWatchState(state))
+      )
+      .subscribe((present) => {
+        const head = this.dirtyState.head;
+        // set initial head state if null
+        if (head === null) {
+          this.dirtyState.head = present;
+          return;
+        }
+
+        // compare against the state that was in the store when we called setHead()
+        const stateIsSame = this.options.comparatorFn!(head, present);
+        if (!stateIsSame) {
+          this.isDirtySubject.next(true);
+        }
+      });
+  }
+
+  isDirty() {
+    return this.isDirtySubject.value;
+  }
+
+  setHead(): void {
+    this.dirtyState.head = this.getWatchState(this.store.getValue());
+    this.isDirtySubject.next(false);
+  }
+
+  getHead(): DirtyCheckProps<State>['head'] {
+    return this.dirtyState.head;
+  }
+
+  reset() {
+    this.dirtyState = {
+      head: null,
+    };
+    this.isDirtySubject.next(false);
+  }
+
+  destroy({ resetState = false }: { resetState?: boolean } = {}) {
+    if (resetState) {
+      this.reset();
+    }
+    this.subscription?.unsubscribe();
+  }
+
+  pause() {
+    this.paused = true;
+  }
+
+  resume() {
+    this.paused = false;
+  }
+
+  private getWatchState(state: State): Partial<State> {
+    return this.options.watch
+      ? this.options.watch.reduce(
+          (watchState, prop) => ({ ...watchState, [prop]: state[prop] }),
+          {}
+        )
+      : state;
+  }
+}
+
+export function dirtyCheck<T extends Store, State extends StoreValue<T>>(
+  store: T,
+  options: Partial<DirtyCheckOptions<State>> = {}
+) {
+  return new DirtyCheck<T, State>(store, options);
 }

--- a/packages/dirty-check/src/lib/dirty-check.ts
+++ b/packages/dirty-check/src/lib/dirty-check.ts
@@ -1,0 +1,3 @@
+export function dirtyCheck(): string {
+  return 'dirty-check';
+}

--- a/packages/dirty-check/tsconfig.json
+++ b/packages/dirty-check/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
+    }
+  ],
+  "compilerOptions": {
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  }
+}

--- a/packages/dirty-check/tsconfig.lib.json
+++ b/packages/dirty-check/tsconfig.lib.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../dist/out-tsc",
+    "declaration": true,
+    "types": []
+  },
+  "include": ["**/*.ts"],
+  "exclude": ["**/*.spec.ts"]
+}

--- a/packages/dirty-check/tsconfig.spec.json
+++ b/packages/dirty-check/tsconfig.spec.json
@@ -1,0 +1,19 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../dist/out-tsc",
+    "module": "commonjs",
+    "types": ["jest", "node"]
+  },
+  "include": [
+    "**/*.test.ts",
+    "**/*.spec.ts",
+    "**/*.test.tsx",
+    "**/*.spec.tsx",
+    "**/*.test.js",
+    "**/*.spec.js",
+    "**/*.test.jsx",
+    "**/*.spec.jsx",
+    "**/*.d.ts"
+  ]
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -14,6 +14,7 @@
     "strict": true,
     "baseUrl": ".",
     "paths": {
+      "@elf/dirty-check": ["packages/dirty-check/src/index.ts"],
       "@ngneat/elf": ["packages/store/src/index.ts"],
       "@ngneat/elf-cli": ["packages/cli/src/index.ts"],
       "@ngneat/elf-cli-ng": ["packages/cli-ng/src/index.ts"],

--- a/workspace.json
+++ b/workspace.json
@@ -4,6 +4,7 @@
     "cli": "packages/cli",
     "cli-ng": "packages/cli-ng",
     "devtools": "packages/devtools",
+    "dirty-check": "packages/dirty-check",
     "entities": "packages/entities",
     "mocks": "packages/mocks",
     "ng": "apps/ng",


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngneat/elf/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## Dirty Check Plugin

We are porting over from akita to elf and I was missing the dirty check plugin from akita.
I felt like contributing this so I had a stab at it.

This does not yet solve the dirty checking for entities, but I though I would get some feedback about what I've done so far before continuing.

The api is modeled after akita, and I've borrowed some of the logic also.
but I also borrowed from the history plugin.

What do you guys think?






