### PR TITLE
feat(entities): moveEntity

### DIFF
--- a/docs/docs/features/entities/entities.mdx
+++ b/docs/docs/features/entities/entities.mdx
@@ -486,6 +486,16 @@ import { deleteAllEntities } from '@ngneat/elf-entities';
 todosStore.update(deleteAllEntities());
 ```
 
+### `moveEntity`
+
+Moves an entity within the store:
+
+```ts
+import { moveEntity } from '@ngneat/elf-entities';
+
+todosStore.update(moveEntity({ fromIndex: 0, toIndex: 1 }));
+```
+
 ## idKey
 
 By default, Elf takes the `id` key from the entity `id` field. To change it, you can pass the `idKey` option to

--- a/packages/entities/src/lib/__snapshots__/move.mutation.spec.ts.snap
+++ b/packages/entities/src/lib/__snapshots__/move.mutation.spec.ts.snap
@@ -1,0 +1,22 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`move should move entity: move 1 to 2 1`] = `
+Object {
+  "entities": Object {
+    "1": Object {
+      "completed": false,
+      "id": 1,
+      "title": "todo 1",
+    },
+    "2": Object {
+      "completed": false,
+      "id": 2,
+      "title": "todo 2",
+    },
+  },
+  "ids": Array [
+    2,
+    1,
+  ],
+}
+`;

--- a/packages/entities/src/lib/move.mutation.spec.ts
+++ b/packages/entities/src/lib/move.mutation.spec.ts
@@ -1,0 +1,21 @@
+import {
+  createEntitiesStore,
+  createTodo,
+  toMatchSnapshot,
+} from '@ngneat/elf-mocks';
+import { addEntities } from './add.mutation';
+import { moveEntity } from './move.mutation';
+
+describe('move', () => {
+  let store: ReturnType<typeof createEntitiesStore>;
+
+  beforeEach(() => {
+    store = createEntitiesStore();
+  });
+
+  it('should move entity', () => {
+    store.update(addEntities([createTodo(1), createTodo(2)]));
+    store.update(moveEntity({ fromIndex: 0, toIndex: 1 }));
+    toMatchSnapshot(expect, store, 'move 1 to 2');
+  });
+});

--- a/packages/entities/src/lib/move.mutation.ts
+++ b/packages/entities/src/lib/move.mutation.ts
@@ -1,0 +1,47 @@
+import { Reducer } from '@ngneat/elf';
+import {
+  DefaultEntitiesRef,
+  EntitiesRef,
+  EntitiesState,
+} from '@ngneat/elf-entities';
+import { BaseEntityOptions, defaultEntitiesRef } from './entity.state';
+
+/**
+ *
+ * Move entity
+ *
+ * @example
+ *
+ * store.update(moveEntity({ fromIndex: 2, toIndex: 3}))
+ *
+ */
+export function moveEntity<
+  S extends EntitiesState<Ref>,
+  Ref extends EntitiesRef = DefaultEntitiesRef
+>(
+  options: {
+    fromIndex: number;
+    toIndex: number;
+  } & BaseEntityOptions<Ref>
+): Reducer<S> {
+  return function (state, context) {
+    const {
+      fromIndex,
+      toIndex,
+      ref: { idsKey, entitiesKey } = defaultEntitiesRef,
+    } = options;
+
+    const ids = state[idsKey].slice();
+    ids.splice(
+      toIndex < 0 ? ids.length + toIndex : toIndex,
+      0,
+      ids.splice(fromIndex, 1)[0]
+    );
+
+    return {
+      ...state,
+      [entitiesKey]: { ...state[entitiesKey] },
+      [idsKey]: ids,
+    };
+  };
+}


### PR DESCRIPTION
in Akita there is a move function on the entities store that moves an id in the ids array to a new position.
This mutator is a copy of the functionality from that function.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngneat/elf/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```
