### PR TITLE
fix(persist-state): wrap storage in try catch

### DIFF
--- a/packages/persist-state/src/lib/storage.ts
+++ b/packages/persist-state/src/lib/storage.ts
@@ -33,9 +33,26 @@ function createStorage(storage: Storage | undefined): StateStorage | undefined {
   };
 }
 
-export const localStorageStrategy = createStorage(
-  typeof localStorage !== 'undefined' ? localStorage : undefined
-)!;
-export const sessionStorageStrategy = createStorage(
-  typeof sessionStorage !== 'undefined' ? sessionStorage : undefined
-)!;
+const tryGetLocalStorage = () => {
+  try {
+    if (typeof localStorage !== 'undefined') {
+      return localStorage;
+    }
+  } catch {
+    // eslint-disable-next-line no-empty
+  }
+  return undefined;
+};
+export const localStorageStrategy = createStorage(tryGetLocalStorage())!;
+
+const tryGetSessionStorage = () => {
+  try {
+    if (typeof sessionStorage !== 'undefined') {
+      return sessionStorage;
+    }
+  } catch {
+    // eslint-disable-next-line no-empty
+  }
+  return undefined;
+};
+export const sessionStorageStrategy = createStorage(tryGetSessionStorage())!;

--- a/packages/persist-state/src/lib/storage.ts
+++ b/packages/persist-state/src/lib/storage.ts
@@ -33,6 +33,9 @@ function createStorage(storage: Storage | undefined): StateStorage | undefined {
   };
 }
 
+// we need to wrap the access to window.localStorage and window.sessionStorage in a try catch
+// because localStorage can be disabled, or be denied by a security rule
+// as soon as we access the property, it throws an error
 const tryGetLocalStorage = () => {
   try {
     if (typeof localStorage !== 'undefined') {


### PR DESCRIPTION
getting localStorage or sessionStorage in an environment where they throw an error, will cause elf to fail.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngneat/elf/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
We don't wrap the access to window.localStorage causing problems.

Issue Number: N/A
https://github.com/ngneat/elf/issues/323

## What is the new behavior?
We wrap the access so that it wont fail in chrome incognito mode.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
