### PR TITLE
docs: add clarification to pagination.mdx

### DIFF
--- a/docs/docs/features/pagination.mdx
+++ b/docs/docs/features/pagination.mdx
@@ -40,6 +40,8 @@ const todosStore = createStore(
 
 Call `updatePaginationData()` with a configuration object that determines the various pagination settings, and call `setPage()` whenever you want to define the `ids` that belong to a certain page number.
 
+`Note: pagination can start at index 0 or 1.`
+
 ```ts title="todos.repository"
 import { PaginationData } from '@ngneat/elf-pagination';
 


### PR DESCRIPTION
As I was using elf state management in my project I referenced the docs, and because of line 55 in pagination.mdx I assumed that elf pagination started at index 1. This cause a lot of extra work for myself, I did not even try to check if there was a page "0". I just wanted to propose some sort of clarification to the docs so that first time users of elf are aware that they can start their pagination at index 0.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngneat/elf/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?
Just some additional documentation for how pagination works. 

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
