### PR TITLE
fix(requests-status): use stricter type for `initializeAsPending`

### DIFF
--- a/packages/requests/src/lib/requests-status.ts
+++ b/packages/requests/src/lib/requests-status.ts
@@ -218,7 +218,7 @@ export function initializeAsPending<T extends string>(keys: OrArray<T>) {
     };
 
     return acc;
-  }, {} as Record<string, PendingState>);
+  }, {} as Record<T, PendingState>);
 }
 
 export function clearRequestsStatus<


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngneat/elf/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Currently, when using the `initializeAsPending` as pending function, the store with request-status is initialized with `Record<string, PendingState>`.

Issue Number: N/A

## What is the new behavior?

As the request-status does support in general string literal unions, the return type of `initializeAsPending` was changed, so that the store has a proper type of  `Record<T, PendingState>`.

## Does this PR introduce a breaking change?

```
[x ] Yes
[ ] No

```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
Before it was possible, at least writing code using request-status keys, that were not initialized. With this change, this will throw a compiler error.
## Other information
