### PR TITLE
feat(pagination): exported pagination state

### DIFF
--- a/packages/pagination/src/lib/pagination.ts
+++ b/packages/pagination/src/lib/pagination.ts
@@ -26,7 +26,7 @@ export interface PaginationData<IdType extends number | string = number> {
   currentPage: IdType;
 }
 
-interface PaginationState<IdType extends number | string = number> {
+export interface PaginationState<IdType extends number | string = number> {
   pagination: {
     pages: Record<IdType, IdType[]>;
   } & PaginationData<IdType>;


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngneat/elf/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
      (only single 'export' statement, no functional changes)
- [ ] Docs have been added / updated (for bug fixes / features)
      (only single 'export' statement, no functional changes)
      
## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[x] Other... Please describe:
```

## What is the current behavior?

Attempting to export a function which has a return type that contains a store with pagination leads to a typescript error:
- `Return type of exported function has or is using name 'PaginationState' from external module "node_modules/@ngneat/elf-pagination/lib/pagination" but cannot be named.ts(4058)`

See discussion #377 

## What is the new behavior?

- PaginationState is exported

## Does this PR introduce a breaking change?

```
[ ] Yes
[X ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
