### PR TITLE
feat(requests):  return cached result option

### DIFF
--- a/packages/requests/src/lib/requests-result.ts
+++ b/packages/requests/src/lib/requests-result.ts
@@ -183,6 +183,8 @@ interface Options {
   staleTime?: number;
   // Ignore everything and perform the request
   skipCache?: boolean;
+  // Return cached result when cache stale
+  alwaysReturnCachedResult?: boolean;
 }
 
 export function trackRequestResult<TData>(
@@ -208,9 +210,12 @@ export function trackRequestResult<TData>(
           status: 'loading',
         });
 
-        setWait(key, true);
+        if (!options?.alwaysReturnCachedResult) {
+          setWait(key, true);
+        }
 
         return source.pipe(
+          tap(() => options?.alwaysReturnCachedResult && setWait(key, true)),
           tap({
             finalize() {
               setWait(key, false);


### PR DESCRIPTION
allows to always return the last cached value when cache is stale

Closes #398

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngneat/elf/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Feature
```

## What is the current behavior?
When cache is stale no value is emitted initially
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #298

## What is the new behavior?
with the alwaysReturnCachedResult option the last cached result ist returned immediatly with loading: true and then the states get updated when the new data arrives

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```