### PR TITLE
feat(requests): support skipping duplicated parellel requests

### DIFF
--- a/docs/docs/features/requests-result.mdx
+++ b/docs/docs/features/requests-result.mdx
@@ -111,6 +111,21 @@ export function fetchTodos() {
 }
 ```
 
+- `preventConcurrentRequest` - Don't perform the request if there is a pending request, defaults to `true`
+
+```ts title="todos.service.ts"
+import { trackRequestResult } from '@ngneat/elf-requests';
+import { setTodos } from './todos.repository';
+
+export function fetchTodos() {
+  return http.get(todosUrl).pipe(
+    tap(setTodos),
+    // highlight-next-line
+    trackRequestResult(['todos'], { preventConcurrentRequest: false })
+  );
+}
+```
+
 ### Operators
 
 ```ts


### PR DESCRIPTION
Introduce skipWhileFetching to options for trackRequestResult function. This allows to skip duplicated parallel requests.

#403

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngneat/elf/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

It is possible to trigger the same request multiple times until the first request is successful

Issue Number: #403

## What is the new behavior?

Introduce skipWhileLoading to options for trackRequestResult function. This allows to skip duplicated parallel requests.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

## Other information
