### PR TITLE
fix: store peer dependencies

### DIFF
--- a/packages/store/package.json
+++ b/packages/store/package.json
@@ -29,6 +29,6 @@
   "license": "MIT",
   "sideEffects": false,
   "peerDependencies": {
-    "rxjs": "*"
+    "rxjs": ">=7.0.0"
   }
 }

--- a/packages/store/package.json
+++ b/packages/store/package.json
@@ -29,6 +29,6 @@
   "license": "MIT",
   "sideEffects": false,
   "peerDependencies": {
-    "typescript": ">= 4.1.2"
+    "rxjs": "*"
   }
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngneat/elf/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Currently this package causes typescript to be a production dependency.

Issue Number: N/A

## What is the new behavior?

Now typescript wont be considered a production dependency which can be ignored when running `npm ci --omit=dev`. Also I added rxjs as a peer dependency as it is actually needed by the store.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
