### PR TITLE
fix(entities): make updateEntities skip updating by entities ids that do not present in the store

### DIFF
--- a/packages/entities/src/lib/__snapshots__/update.mutation.spec.ts.snap
+++ b/packages/entities/src/lib/__snapshots__/update.mutation.spec.ts.snap
@@ -340,6 +340,21 @@ Object {
 }
 `;
 
+exports[`update should update by callback: completed true 2`] = `
+Object {
+  "entities": Object {
+    "1": Object {
+      "completed": true,
+      "id": 1,
+      "title": "todo 1",
+    },
+  },
+  "ids": Array [
+    1,
+  ],
+}
+`;
+
 exports[`update should update by predicate: completed false 1`] = `
 Object {
   "entities": Object {
@@ -424,6 +439,27 @@ Object {
 }
 `;
 
+exports[`update should update multiple entities: multi completed true 2`] = `
+Object {
+  "entities": Object {
+    "1": Object {
+      "completed": true,
+      "id": 1,
+      "title": "todo 1",
+    },
+    "2": Object {
+      "completed": true,
+      "id": 2,
+      "title": "todo 2",
+    },
+  },
+  "ids": Array [
+    1,
+    2,
+  ],
+}
+`;
+
 exports[`update should update one entity: completed false 1`] = `
 Object {
   "entities": Object {
@@ -440,6 +476,21 @@ Object {
 `;
 
 exports[`update should update one entity: completed true 1`] = `
+Object {
+  "entities": Object {
+    "1": Object {
+      "completed": true,
+      "id": 1,
+      "title": "todo 1",
+    },
+  },
+  "ids": Array [
+    1,
+  ],
+}
+`;
+
+exports[`update should update one entity: completed true 2`] = `
 Object {
   "entities": Object {
     "1": Object {

--- a/packages/entities/src/lib/update.mutation.spec.ts
+++ b/packages/entities/src/lib/update.mutation.spec.ts
@@ -29,12 +29,18 @@ describe('update', () => {
     toMatchSnapshot(expect, store, 'completed false');
     store.update(updateEntities(1, { completed: true }));
     toMatchSnapshot(expect, store, 'completed true');
+    // store shouldn't be changed since there's no entity with id 2
+    store.update(updateEntities(2, { completed: true }));
+    toMatchSnapshot(expect, store, 'completed true');
   });
 
   it('should update multiple entities', () => {
     store.update(addEntities([createTodo(1), createTodo(2)]));
     toMatchSnapshot(expect, store, 'multi completed false');
     store.update(updateEntities([1, 2], { completed: true }));
+    toMatchSnapshot(expect, store, 'multi completed true');
+    // store shouldn't be changed since there's no entities with ids 3 and 4
+    store.update(updateEntities([3, 4], { completed: true }));
     toMatchSnapshot(expect, store, 'multi completed true');
   });
 
@@ -43,6 +49,11 @@ describe('update', () => {
     toMatchSnapshot(expect, store, 'completed false');
     store.update(
       updateEntities(1, (todo) => ({ ...todo, completed: !todo.completed }))
+    );
+    toMatchSnapshot(expect, store, 'completed true');
+    // store shouldn't be changed since there's no entity with id 2
+    store.update(
+      updateEntities(2, (todo) => ({ ...todo, completed: !todo.completed }))
     );
     toMatchSnapshot(expect, store, 'completed true');
   });

--- a/packages/entities/src/lib/update.mutation.ts
+++ b/packages/entities/src/lib/update.mutation.ts
@@ -12,7 +12,7 @@ import {
   ItemPredicate,
 } from './entity.state';
 import { findIdsByPredicate } from './entity.utils';
-import { hasEntity } from './queries';
+import { hasEntity, getEntity } from './queries';
 
 export type UpdateFn<Entity> = Partial<Entity> | ((entity: Entity) => Entity);
 
@@ -55,10 +55,12 @@ export function updateEntities<
     >;
 
     for (const id of coerceArray(ids)) {
-      updatedEntities[id] = toModel<getEntityType<S, Ref>>(
-        updater,
-        state[entitiesKey][id]
-      );
+      if (hasEntity(id, options)(state)) {
+        updatedEntities[id] = toModel<getEntityType<S, Ref>>(
+          updater,
+          getEntity(id, options)(state)
+        );
+      }
     }
 
     return {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngneat/elf/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: https://github.com/ngneat/elf/issues/437

## What is the new behavior?

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
