### PR TITLE
feat(requests): support caching response data in request result (#443)

### DIFF
--- a/docs/docs/features/requests-result.mdx
+++ b/docs/docs/features/requests-result.mdx
@@ -126,7 +126,7 @@ export function fetchTodos() {
 }
 ```
 
-- `cacheResponseData` - Cache the response data and emit it as data for skipped requests, defaults to `false`
+- `cacheResponseData` - Cache the response data and emit it as responseData for skipped requests, defaults to `false`
 
 ```ts title="todos.service.ts"
 import { trackRequestResult } from '@ngneat/elf-requests';
@@ -139,6 +139,10 @@ export function fetchTodos() {
     trackRequestResult(['todos'], { cacheResponseData: true })
   );
 }
+
+fetchTodos().subscribe((todos) => {
+  // This will be called with the cached result, or once the request is completed
+});
 ```
 
 ### Operators

--- a/docs/docs/features/requests-result.mdx
+++ b/docs/docs/features/requests-result.mdx
@@ -126,6 +126,21 @@ export function fetchTodos() {
 }
 ```
 
+- `cacheResponseData` - Cache the response data and emit it as data for skipped requests, defaults to `false`
+
+```ts title="todos.service.ts"
+import { trackRequestResult } from '@ngneat/elf-requests';
+import { setTodos } from './todos.repository';
+
+export function fetchTodos() {
+  return http.get(todosUrl).pipe(
+    tap(setTodos),
+    // highlight-next-line
+    trackRequestResult(['todos'], { cacheResponseData: true })
+  );
+}
+```
+
 ### Operators
 
 ```ts


### PR DESCRIPTION
Introduce cacheResponseData to options for trackRequestResult function. This allows to cache the response data and return it in consecutive calls of the cached request

#443

## PR Checklist

Please check if your PR fulfills the following requirements:

- [/] The commit message follows our guidelines: https://github.com/ngneat/elf/blob/master/CONTRIBUTING.md#commit
- [/] Tests for the changes have been added (for bug fixes / features)
- [/] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

For skipped requests the trackRequestResult operator returns an empty observable.

Issue Number: 443

## What is the new behavior?

For skipped requests the trackRequestResult operator returns the same data (or error) like the original request. This behavior needs to be activated by using the cacheResponseData options of the trackRequestResult operator.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
