### PR TITLE
fix(entities): 🐞 remove redundant idkey from selectEntityByPred

### DIFF
--- a/docs/docs/features/entities-management/entities.mdx
+++ b/docs/docs/features/entities-management/entities.mdx
@@ -112,13 +112,11 @@ const todo$ = todosStore.pipe(
 const title$ = todosStore.pipe(
   selectEntityByPredicate(({ completed }) => !completed, {
     pluck: 'title',
-    idKey: '_id',
   })
 );
 const title$ = todosStore.pipe(
   selectEntityByPredicate(({ completed }) => !completed, {
     pluck: (e) => e.title,
-    idKey: '_id',
   })
 );
 ```

--- a/packages/entities/src/lib/entity.query.ts
+++ b/packages/entities/src/lib/entity.query.ts
@@ -176,18 +176,10 @@ export function selectEntityByPredicate<
   } & BaseEntityOptions<Ref> &
     IdKey
 ): OperatorFunction<S, getEntityType<S, Ref> | undefined> {
-  const { ref = defaultEntitiesRef, pluck, idKey = 'id' } = options || {};
-  const { entitiesKey } = ref;
+  const { ref = defaultEntitiesRef, pluck } = options || {};
 
-  let id: getIdType<S, Ref>;
   return pipe(
-    select<S, Ref>((state) => {
-      if (isUndefined(id)) {
-        const entity = findEntityByPredicate(state, ref, predicate);
-        id = entity && entity[idKey];
-      }
-      return state[entitiesKey][id];
-    }),
+    select<S, Ref>((state) => findEntityByPredicate(state, ref, predicate)),
     map((entity) => (entity ? checkPluck(entity, pluck) : undefined)),
     distinctUntilChanged()
   );


### PR DESCRIPTION
BREAKING CHANGE: 🧨 The selectEntityByPredicate function doesn't support the idKey anymore

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/ngneat/elf/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

```
[ ] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
