### PR TITLE
fix(requests): expose RequestResult

### DIFF
--- a/packages/requests/src/index.ts
+++ b/packages/requests/src/index.ts
@@ -33,4 +33,5 @@ export {
   filterSuccess,
   mapResultData,
   resetStaleTime,
+  RequestResult,
 } from './lib/requests-result';


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngneat/elf/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

At this moment, the requests package doesn't expose the [RequestResult](https://github.com/ngneat/elf/blob/master/packages/requests/src/lib/requests-result.ts#L59) type even though it is mentioned in the [docs](https://ngneat.github.io/elf/docs/features/requests-result/#api).

## What is the new behavior?

Similarly to [Request Status](https://ngneat.github.io/elf/docs/features/requests/requests-status/) (see [StatusState](https://github.com/ngneat/elf/blob/master/packages/requests/src/index.ts#L15) type), this PR is exposing the [RequestResult](https://github.com/ngneat/elf/blob/master/packages/requests/src/lib/requests-result.ts#L59) type so that e.g. [joinRequestResult](https://github.com/ngneat/elf/blob/master/packages/requests/src/lib/requests-result.ts#L163) can be properly typed.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
