### PR TITLE
feat: add OpenGraph and Twitter attributes to header

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -14,10 +14,20 @@ module.exports = {
   organizationName: 'ngneat',
   projectName: 'elf',
   themeConfig: {
-    metadata: [{
-      name: 'google-site-verification',
-      content: 'zLIQAxOp2sGFy10UE51HAMtWTqg7J8z1hpTxZR9G1WA'
-    }],
+    metadata: [
+      { name: 'google-site-verification', content: 'zLIQAxOp2sGFy10UE51HAMtWTqg7J8z1hpTxZR9G1WA' },
+      { name: 'twitter:card', content: 'summary_large_image' },
+      { property: 'twitter:domain', content: 'ngneat.github.io' },
+      { property: 'twitter:url', content: 'https://ngneat.github.io/elf/' },
+      { name: 'twitter:title', content: 'Elf 🧝' },
+      { name: 'twitter:description', content: 'A Reactive Store with Magical Powers' },
+      { name: 'twitter:image', content: 'https://ngneat.github.io/elf/img/elf.png' },
+      { property: 'og:url', content: 'https://ngneat.github.io/elf/' },
+      { property: 'og:type', content: 'website' },
+      { property: 'og:title', content: 'Elf 🧝' },
+      { property: 'og:description', content: 'A Reactive Store with Magical Powers' },
+      { property: 'og:image', content: 'https://ngneat.github.io/elf/img/elf.png' },
+    ],
     algolia: {
       appId: 'GSDPQ4A8PM',
       apiKey: 'a7655f6472e9024f257027fa9b4e9e7e',


### PR DESCRIPTION
This update includes OpenGraph and Twitter attributes in the HTML header. This enhances sharing experiences on social media. Shared content now presents more rich and relevant information.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngneat/elf/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

[As can be seen here](https://www.opengraph.xyz/url/https%3A%2F%2Fngneat.github.io%2Felf%2F), sharing Elf's url does not look good -
<img width="507" alt="image" src="https://github.com/ngneat/elf/assets/10364499/e3f7b9d3-1121-4f26-8bb8-44b45285ff5d">


## What is the new behavior?

When this changes are deployed, sharing Elf would look like this -

<img width="464" alt="image" src="https://github.com/ngneat/elf/assets/10364499/58109d4d-6553-4f3c-b39a-937d196bfa07">


## Does this PR introduce a breaking change?

```
[ ] Yes
[ X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
