### PR TITLE
fix(requests): staleTime can be undefined

### DIFF
--- a/packages/requests/src/lib/requests-result.ts
+++ b/packages/requests/src/lib/requests-result.ts
@@ -185,19 +185,19 @@ interface Options<TData> {
   // Wheteher to cache the response data
   cacheResponseData?: boolean;
   // Whether to cache request result for any additional keys
-  additionalKeys?: (_: TData) => unknown[][],
+  additionalKeys?: (_: TData) => unknown[][];
 }
 
 export function trackRequestResult<TData>(
   key: unknown[],
-  options?: Options<TData>,
+  options?: Options<TData>
 ): MonoTypeOperatorFunction<TData> {
   return function (source: Observable<TData>) {
     return getRequestResult(key).pipe(
       take(1),
       switchMap((result) => {
         const stale = options?.staleTime
-          ? result.staleTime! < Date.now()
+          ? (result.staleTime ?? 0) < Date.now()
           : false;
 
         const preventConcurrentRequest =


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:
- [x] The commit message follows our guidelines: https://github.com/ngneat/elf/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
```
[x] Bugfix
```

## What is the current behavior?

When using resetStaleTime staleTime becomes undefined and then the check fails, because it compares undefined < Date.now()

## What is the new behavior?

We use 0 instead of undefined for staleTime, that it doesn't fail with undefined

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

## Other information

We could also change resetStaleTime to reset the staleTime to 0 instead of undefined.