### PR TITLE
Add NPM Usage Trend Link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,3 +80,6 @@ export function updateFilter(filter: TodosProps['filter']) {
 - [`@ngneat/persist-state`](https://github.com/ngneat/elf/blob/master/packages/persist-state/CHANGELOG.md)
 - [`@ngneat/requests`](https://github.com/ngneat/elf/blob/master/packages/requests/CHANGELOG.md)
 - [`@ngneat/state-history`](https://github.com/ngneat/elf/blob/master/packages/state-history/CHANGELOG.md)
+
+## ⭐ Usage Trend of Elf Packages
+[Usage Trend of Elf Packages](https://npm-compare.com/@ngneat/elf,@ngneat/elf-entities,@ngneat/elf-devtools,@ngneat/elf-persist-state,@ngneat/elf-requests,@ngneat/elf-pagination,@ngneat/elf-cli-ng,@ngneat/elf-state-history,@ngneat/elf-cli)


### PR DESCRIPTION
## PR Checklist
[x] Docs have been added

## PR Type

[x] Documentation content changes

## Other information

 I've been a dedicated user of the Elf family of packages, and I'm continuously impressed by the quality and usefulness of these libraries. I wanted to suggest an enhancement that could further improve the user experience for everyone who uses these packages.

I've noticed that the README for the Elf family packages doesn't currently include a link to an NPM usage trend tool. Adding such a link would allow users to easily access important metrics such as usage trends, the latest commit time, and GitHub star counts for each of the Elf family packages.

I believe that providing easy access to these metrics will be beneficial for both new users exploring these packages and existing users who want to stay updated with their popularity.

Thank you once again for your outstanding contributions to the community.