### PR TITLE
fix(requests): preventConcurrentRequest along with staleTime

### DIFF
--- a/packages/requests/src/lib/requests-result.ts
+++ b/packages/requests/src/lib/requests-result.ts
@@ -214,8 +214,7 @@ export function trackRequestResult<TData>(
         if (
           result.fetchStatus === 'fetching' &&
           preventConcurrentRequest &&
-          !options?.skipCache &&
-          !stale
+          !options?.skipCache
         ) {
           return getRequestResult(key).pipe(
             filter((requestResult) => requestResult.fetchStatus === 'idle'),


### PR DESCRIPTION
This fixes #485 

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngneat/elf/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

trackRequestResult no longer considers staleTime when skipping a request with status: fetching.

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

It's currently possible to have concurrent requests even if preventConcurrentRequest is true because all requests that are 'fetching' are also stale.

Issue Number: #485 

## What is the new behavior?

The stale time is not considered at all when deciding wether to skip a request or not for fetching requests.

An alternative solution would be to set the stale time for request that are fetching, but this seems like a cleaner solution.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

I cannot see a reason this would be breaking.
