### PR TITLE
feat: add support for removing a single request cache by key(#515)

### DIFF
--- a/docs/docs/features/requests/requests-cache.mdx
+++ b/docs/docs/features/requests/requests-cache.mdx
@@ -216,3 +216,13 @@ import { clearRequestsCache } from '@ngneat/elf-requests';
 
 store.update(clearRequestsCache());
 ```
+
+### `deleteRequestsCache`
+
+```ts
+import { deleteRequestsCache } from '@ngneat/elf-requests';
+
+store.update(deleteRequestsCache('keyOne'));
+
+store.update(deleteRequestsCache(['keyOne', 'keyTwo']));
+```

--- a/packages/requests/src/index.ts
+++ b/packages/requests/src/index.ts
@@ -7,6 +7,7 @@ export {
   selectRequestCache,
   selectIsRequestCached,
   clearRequestsCache,
+  deleteRequestsCache,
   updateRequestsCache,
 } from './lib/requests-cache';
 

--- a/packages/requests/src/lib/requests-cache.spec.ts
+++ b/packages/requests/src/lib/requests-cache.spec.ts
@@ -2,6 +2,7 @@ import { createState, Store } from '@ngneat/elf';
 import {
   CacheState,
   clearRequestsCache,
+  deleteRequestsCache,
   getRequestCache,
   isRequestCached,
   selectIsRequestCached,
@@ -15,9 +16,8 @@ import { expectTypeOf } from 'expect-type';
 import { createRequestsCacheOperator } from '..';
 
 describe('requestsCache', () => {
-  const { state, config } = createState(
-    withRequestsCache<'users' | `user-${string}`>()
-  );
+  const { state, config } =
+    createState(withRequestsCache<'users' | `user-${string}`>());
   const store = new Store({ state, config, name: 'users' });
 
   it('should work', () => {
@@ -60,14 +60,13 @@ describe('requestsCache', () => {
     // It's partial not full
     expect(store.query(isRequestCached('users'))).toBeFalsy();
     expect(
-      store.query(isRequestCached('users', { value: 'partial' }))
+      store.query(isRequestCached('users', { value: 'partial' })),
     ).toBeTruthy();
   });
 
   it('should updateRequestCache', () => {
-    const { state, config } = createState(
-      withRequestsCache<'users' | `user-${string}`>()
-    );
+    const { state, config } =
+      createState(withRequestsCache<'users' | `user-${string}`>());
     const store = new Store({ state, config, name: 'users' });
     const key = 'users';
 
@@ -78,7 +77,7 @@ describe('requestsCache', () => {
     store.update(updateRequestCache(key, { value: 'partial' }));
     expect(store.query(isRequestCached(key))).toBeFalsy();
     expect(
-      store.query(isRequestCached(key, { value: 'partial' }))
+      store.query(isRequestCached(key, { value: 'partial' })),
     ).toBeTruthy();
 
     store.update(updateRequestCache(key, { value: 'none' }));
@@ -87,9 +86,8 @@ describe('requestsCache', () => {
   });
 
   it('should skipWhileCached', () => {
-    const { state, config } = createState(
-      withRequestsCache<'users' | `user-${string}`>()
-    );
+    const { state, config } =
+      createState(withRequestsCache<'users' | `user-${string}`>());
     const store = new Store({ state, config, name: 'users' });
     const skipWhileUsersCached = createRequestsCacheOperator(store);
 
@@ -113,9 +111,8 @@ describe('requestsCache', () => {
   });
 
   it('should uphold ttl', () => {
-    const { state, config } = createState(
-      withRequestsCache<'users' | `user-${string}`>()
-    );
+    const { state, config } =
+      createState(withRequestsCache<'users' | `user-${string}`>());
     const store = new Store({ state, config, name: 'users' });
 
     jest.useFakeTimers();
@@ -124,25 +121,25 @@ describe('requestsCache', () => {
     store.update(updateRequestCache(ttlRequestKey, { ttl: 1000 }));
 
     expect(
-      store.query(isRequestCached(ttlRequestKey, { value: 'full' }))
+      store.query(isRequestCached(ttlRequestKey, { value: 'full' })),
     ).toBeTruthy();
 
     jest.advanceTimersByTime(2000);
 
     expect(
-      store.query(isRequestCached(ttlRequestKey, { value: 'full' }))
+      store.query(isRequestCached(ttlRequestKey, { value: 'full' })),
     ).toBeFalsy();
 
     store.update(updateRequestCache(ttlRequestKey, { ttl: 1000 }));
 
     expect(
-      store.query(isRequestCached(ttlRequestKey, { value: 'full' }))
+      store.query(isRequestCached(ttlRequestKey, { value: 'full' })),
     ).toBeTruthy();
 
     jest.advanceTimersByTime(2000);
 
     expect(
-      store.query(isRequestCached(ttlRequestKey, { value: 'full' }))
+      store.query(isRequestCached(ttlRequestKey, { value: 'full' })),
     ).toBeFalsy();
 
     jest.useRealTimers();
@@ -175,10 +172,77 @@ describe('requestsCache', () => {
   });
 });
 
+describe('deleteRequestsCache', () => {
+  let store: Store;
+
+  beforeEach(() => {
+    const { state, config } = createState(withRequestsCache<'qux' | 'fred'>());
+
+    store = new Store({ state, config, name: 'users' });
+
+    store.update(
+      updateRequestsCache({
+        qux: {
+          value: 'full',
+        },
+        fred: {
+          value: 'full',
+        },
+      }),
+    );
+
+    expect(store.getValue()).toMatchInlineSnapshot(`
+      Object {
+        "requestsCache": Object {
+          "fred": Object {
+            "value": "full",
+          },
+          "qux": Object {
+            "value": "full",
+          },
+        },
+      }
+    `);
+  });
+
+  it('should clear single key', () => {
+    store.update(deleteRequestsCache('qux'));
+
+    expect(store.getValue()).toMatchInlineSnapshot(`
+      Object {
+        "requestsCache": Object {
+          "fred": Object {
+            "value": "full",
+          },
+          "qux": Object {
+            "value": "none",
+          },
+        },
+      }
+    `);
+  });
+
+  it('should clear all keys', () => {
+    store.update(deleteRequestsCache(['qux', 'fred']));
+
+    expect(store.getValue()).toMatchInlineSnapshot(`
+      Object {
+        "requestsCache": Object {
+          "fred": Object {
+            "value": "none",
+          },
+          "qux": Object {
+            "value": "none",
+          },
+        },
+      }
+    `);
+  });
+});
+
 test('updateRequestsCache', () => {
-  const { state, config } = createState(
-    withRequestsCache<'foo' | 'bar' | 'baz'>()
-  );
+  const { state, config } =
+    createState(withRequestsCache<'foo' | 'bar' | 'baz'>());
 
   const store = new Store({ state, config, name: 'users' });
 
@@ -187,7 +251,7 @@ test('updateRequestsCache', () => {
       foo: {
         value: 'partial',
       },
-    })
+    }),
   );
 
   expect(store.getValue()).toMatchSnapshot();
@@ -200,7 +264,7 @@ test('updateRequestsCache', () => {
       bar: {
         value: 'full',
       },
-    })
+    }),
   );
 
   expect(store.getValue()).toMatchSnapshot();
@@ -211,24 +275,23 @@ test('updateRequestsCache', () => {
 });
 
 test('updateRequestsCache with ttl', () => {
-  const { state, config } = createState(
-    withRequestsCache<'foo' | 'bar' | 'baz'>()
-  );
+  const { state, config } =
+    createState(withRequestsCache<'foo' | 'bar' | 'baz'>());
 
   const store = new Store({ state, config, name: 'users' });
 
   jest.useFakeTimers();
 
   store.update(
-    updateRequestsCache(['foo', 'bar'], { value: 'partial', ttl: 1000 })
+    updateRequestsCache(['foo', 'bar'], { value: 'partial', ttl: 1000 }),
   );
 
   expect(
-    store.query(isRequestCached('foo', { value: 'partial' }))
+    store.query(isRequestCached('foo', { value: 'partial' })),
   ).toBeTruthy();
 
   expect(
-    store.query(isRequestCached('bar', { value: 'partial' }))
+    store.query(isRequestCached('bar', { value: 'partial' })),
   ).toBeTruthy();
 
   jest.advanceTimersByTime(2000);

--- a/packages/requests/src/lib/requests-cache.ts
+++ b/packages/requests/src/lib/requests-cache.ts
@@ -33,7 +33,7 @@ export type CacheState = {
 };
 
 export function withRequestsCache<Keys extends string>(
-  initialValue?: Record<Keys, CacheState>
+  initialValue?: Record<Keys, CacheState>,
 ): PropsFactory<{ requestsCache: Record<Keys, CacheState> }, EmptyConfig> {
   return {
     props: {
@@ -44,17 +44,17 @@ export function withRequestsCache<Keys extends string>(
 }
 
 export function selectRequestCache<S extends RequestsCacheState>(
-  key: CacheRecordKeys<S>
+  key: CacheRecordKeys<S>,
 ): OperatorFunction<S, CacheState> {
   return pipe(
     distinctUntilKeyChanged('requestsCache'),
-    select((state) => getRequestCache(key)(state))
+    select((state) => getRequestCache(key)(state)),
   );
 }
 
 export function updateRequestsCache<S extends RequestsCacheState>(
   keys: Array<CacheRecordKeys<S>>,
-  value: CacheState | { value: CacheState['value']; ttl?: number }
+  value: CacheState | { value: CacheState['value']; ttl?: number },
 ): Reducer<S>;
 export function updateRequestsCache<S extends RequestsCacheState>(
   requests: Partial<
@@ -62,11 +62,11 @@ export function updateRequestsCache<S extends RequestsCacheState>(
       CacheRecordKeys<S>,
       CacheState | { value: CacheState['value']; ttl?: number }
     >
-  >
+  >,
 ): Reducer<S>;
 export function updateRequestsCache<S extends RequestsCacheState>(
   requestsOrKeys: any,
-  value?: any
+  value?: any,
 ): Reducer<S> {
   let normalized = requestsOrKeys;
 
@@ -99,7 +99,7 @@ export function updateRequestsCache<S extends RequestsCacheState>(
 
 export function updateRequestCache<S extends RequestsCacheState>(
   key: CacheRecordKeys<S>,
-  { ttl, value: v }: { ttl?: number; value?: CacheState['value'] } = {}
+  { ttl, value: v }: { ttl?: number; value?: CacheState['value'] } = {},
 ): Reducer<S> {
   const data = {
     value: v ?? 'full',
@@ -120,7 +120,7 @@ export function updateRequestCache<S extends RequestsCacheState>(
 }
 
 export function getRequestCache<S extends RequestsCacheState>(
-  key: CacheRecordKeys<S>
+  key: CacheRecordKeys<S>,
 ): Query<S, CacheState> {
   return function (state: S) {
     const cacheValue =
@@ -141,22 +141,22 @@ export function getRequestCache<S extends RequestsCacheState>(
 
 export function selectIsRequestCached<S extends RequestsCacheState>(
   key: Parameters<typeof isRequestCached>[0],
-  options?: { value?: CacheState['value'] }
+  options?: { value?: CacheState['value'] },
 ): OperatorFunction<S, boolean> {
   return pipe(
     distinctUntilKeyChanged('requestsCache'),
-    select((state) => isRequestCached(key, options)(state))
+    select((state) => isRequestCached(key, options)(state)),
   );
 }
 
 export function isRequestCached<S extends RequestsCacheState>(
   key: OrArray<CacheRecordKeys<S>>,
-  options?: { value?: CacheState['value'] }
+  options?: { value?: CacheState['value'] },
 ) {
   return function (state: S) {
     const type = options?.value ?? 'full';
     return coerceArray(key).some(
-      (k) => getRequestCache(k)(state).value === type
+      (k) => getRequestCache(k)(state).value === type,
     );
   };
 }
@@ -164,7 +164,7 @@ export function isRequestCached<S extends RequestsCacheState>(
 export function skipWhileCached<S extends RequestsCacheState, T>(
   store: Store<StoreDef<S>>,
   key: OrArray<CacheRecordKeys<S>>,
-  options?: { value?: CacheState['value']; returnSource?: Observable<any> }
+  options?: { value?: CacheState['value']; returnSource?: Observable<any> },
 ): MonoTypeOperatorFunction<T> {
   return function (source: Observable<T>) {
     if (store.query(isRequestCached(key, { value: options?.value }))) {
@@ -176,11 +176,11 @@ export function skipWhileCached<S extends RequestsCacheState, T>(
 }
 
 export function createRequestsCacheOperator<S extends RequestsCacheState>(
-  store: Store<StoreDef<S>>
+  store: Store<StoreDef<S>>,
 ) {
   return function <T>(
     key: CacheRecordKeys<S>,
-    options?: Parameters<typeof skipWhileCached>[2]
+    options?: Parameters<typeof skipWhileCached>[2],
   ) {
     return skipWhileCached<S, T>(store, key, options);
   };
@@ -193,4 +193,12 @@ export function clearRequestsCache<S extends RequestsCacheState>(): Reducer<S> {
       requestsCache: {},
     };
   };
+}
+
+export function deleteRequestsCache<S extends RequestsCacheState>(
+  keys: OrArray<CacheRecordKeys<S>>,
+): Reducer<S> {
+  return updateRequestsCache(coerceArray(keys), {
+    value: 'none',
+  });
 }


### PR DESCRIPTION
New function 'deleteRequestsCache'

resolves #515

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngneat/elf/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

@ngneat/elf-requests does not support removing a single request cache by key

Issue Number: #515 

## What is the new behavior?

New function 'deleteRequestsCache' can invalidate in cache a single key or list of keys

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
