### PR TITLE
fix(entities): correct behavior of `upsertEntities` with duplicate entities

### DIFF
--- a/packages/entities/src/lib/update.mutation.spec.ts
+++ b/packages/entities/src/lib/update.mutation.spec.ts
@@ -259,6 +259,19 @@ describe('update', () => {
 
       expect(ids).toBe(sameIds);
     });
+
+    it('should be able to handle duplicate ids', () => {
+      const store = createEntitiesStore();
+      store.update(
+        upsertEntities([
+          { id: 1, completed: true },
+          { id: 1, completed: false },
+        ]),
+      );
+      const { ids, entities } = store.getValue();
+      expect(ids).toEqual([1]);
+      expect(entities).toEqual({ 1: { id: 1, completed: false } });
+    });
   });
 
   describe('UpdateEntitiesIds', () => {

--- a/packages/entities/src/lib/update.mutation.ts
+++ b/packages/entities/src/lib/update.mutation.ts
@@ -228,8 +228,9 @@ export function upsertEntities<
 
     for (const entity of entitiesArray) {
       const id: getIdType<S, Ref> = entity[idKey];
-      // if entity exists, merge update, else add
-      if (hasEntity(id, options)(state)) {
+      if (asObject[id]) {
+        asObject[id] = { ...asObject[id], ...entity };
+      } else if (hasEntity(id, options)(state)) {
         asObject[id] = { ...state[entitiesKey][id], ...entity };
         updatedEntitiesId.push(id);
       } else {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngneat/elf/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #518 

## What is the new behavior?

For duplicate entities, the latter one will be merged into the former one. The resulting `ids` array will not have duplicate ids.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
